### PR TITLE
docs: 添加 STS Mod 开发踩坑规范技能与调研文档

### DIFF
--- a/docs/customplayer-resources-pitfalls.md
+++ b/docs/customplayer-resources-pitfalls.md
@@ -1,0 +1,692 @@
+# CustomPlayer 资源相关坑点指南
+
+本文档归纳了开发 STS 角色类 mod 时常见的资源加载问题，聚焦 CustomPlayer、Spine 动画、能量球、角色选择界面、TopPanel/tooltip、渲染相关。
+
+## 1. 资源加载失败/路径问题
+
+### 1.1 路径大小写敏感
+
+**现象**：
+- Windows 下正常，Linux/Mac 下游戏崩溃或资源加载失败
+- 报错通常为 `File not found` 或 `NullPointerException`
+
+**根因**：
+- Linux 文件系统区分大小写，Windows 不区分
+- 代码中的路径与实际文件名大小写不匹配
+
+**推荐做法**：
+```java
+// 错误示例：大小写不一致
+loadAnimation("ModResources/images/char/Player.atlas", ...);  // 文件实际是 player.atlas
+
+// 正确做法：使用工具函数统一路径管理
+public class ModPaths {
+    public static String makeCharPath(String file) {
+        return "ModResources/images/char/" + file;
+    }
+}
+// 调用时
+loadAnimation(ModPaths.makeCharPath("player.atlas"), ModPaths.makeCharPath("player.json"), 1.0F);
+```
+
+**证据指针**：
+- `Downfall/sneckomod/TheSnecko.java:51` - 使用动态路径变量
+- `LingMod/lingmod/character/Ling.java:77-80` - 使用 `ModCore.makeCharacterPath()` 构建路径
+
+**自检清单**：
+```bash
+# 1. 检查代码中的路径与实际文件名大小写是否匹配
+find ../resources/mods -name "*.java" -exec grep -l "\.atlas\|\.json" {} \; | xargs grep -oh "[^\"']*\.[Aa][Tt][Ll][Aa][Ss]"
+
+# 2. 在 Linux 环境运行 mod，查看日志中的文件路径报错
+grep -i "file not found\|nullpointer" ~/Library/Logs/STS/log.txt
+```
+
+---
+
+### 1.2 打包进 jar 后路径变化
+
+**现象**：
+- IDE 运行正常，打包后游戏崩溃
+- 报错信息包含 `classpath` 或 `ClassLoader` 相关
+
+**根因**：
+- 开发时使用 `File API` 访问文件系统路径
+- 打包后资源在 jar 内，必须使用 `ClassLoader.getResource()`
+
+**推荐做法**：
+```java
+// 错误示例：使用 File API
+File file = new File("images/char/player.png");  // 打包后无法访问
+
+// 正确做法：使用 Gdx.files.internal 或 ClassLoader
+Texture tex = new Texture(Gdx.files.internal("ModResources/images/char/player.png"));
+// BaseMod 会自动处理资源路径
+```
+
+**证据指针**：
+- `BaseMod/basemod/abstracts/CustomPlayer.java:212` - 使用 `Gdx.files.internal` 加载按钮图标
+- `AnonMod/characters/char_Anon.java:83` - 直接使用 `new SpriterAnimation(filepath)` 依赖 BaseMod 路径解析
+
+**自检清单**：
+```bash
+# 1. 搜索是否有直接 new File() 的用法
+grep -rn "new File\(" ../resources/mods --include="*.java"
+
+# 2. 确认 ModTheSpire.json 中声明了 resources 目录
+grep -A5 "\"resources\"" ../resources/mods/*/ModTheSpire.json
+```
+
+---
+
+### 1.3 atlas-json 配对错误
+
+**现象**：
+- 角色动画不显示或显示错乱
+- 控制台报 `Spine: Skeleton not found` 或 `Atlas region not found`
+
+**根因**：
+- `.atlas` 文件和 `.json` 文件不匹配
+- 使用了不同版本的 Spine 导出
+- 文件名前缀不一致
+
+**推荐做法**：
+```java
+// 确保同名配对
+String basePath = "ModResources/images/char/player";
+loadAnimation(basePath + ".atlas", basePath + ".json", 1.0F);
+
+// 验证文件存在性
+if (Gdx.files.internal(basePath + ".atlas").exists() &&
+    Gdx.files.internal(basePath + ".json").exists()) {
+    loadAnimation(...);
+} else {
+    logger.error("Spine resources not found: " + basePath);
+}
+```
+
+**证据指针**：
+- `BaseMod/basemod/abstracts/CustomPlayer.java:78` - 构造函数中自动调用 `loadAnimation`
+- `Downfall/sneckomod/TheSnecko.java:51` - 使用动态路径确保配对
+
+**自检清单**：
+```bash
+# 1. 检查 atlas 和 json 文件是否成对存在
+find ../resources/mods -name "*.atlas" | while read f; do
+  json="${f%.atlas}.json"
+  if [ ! -f "$json" ]; then echo "Missing pair: $f"; fi
+done
+
+# 2. 检查 Spine 版本一致性（注释头应匹配）
+head -n1 ../resources/mods/*/images/char/*.atlas
+```
+
+---
+
+### 1.4 资源未放在 ModTheSpire.json 声明的 resources 目录
+
+**现象**：
+- IDE 运行正常，打包后资源加载失败
+- 报错 `Resource not found: xxxResources/...`
+
+**根因**：
+- `ModTheSpire.json` 未声明资源目录，或声明路径与实际不符
+- 代码中使用的资源前缀与声明不一致
+
+**推荐做法**：
+```json
+// ModTheSpire.json
+{
+  "modLoader": "java",
+  "launcher": "default",
+  "resources": [
+    "ModResources/"
+  ]
+}
+```
+
+```java
+// 代码中的路径前缀必须与声明一致
+public static final String RESOURCE_PATH = "ModResources/";
+loadAnimation(RESOURCE_PATH + "images/char/player.atlas", ...);
+```
+
+**证据指针**：
+- `LingMod/lingmod/ModCore.java:makeCharacterPath()` - 使用统一前缀 `ModResources`
+- `Koishi/Koishi/characters/KoishiCharacter.java:51` - 使用 `KoishiResources` 前缀
+
+**自检清单**：
+```bash
+# 1. 检查 ModTheSpire.json 中的 resources 声明
+grep -h "\"resources\"" -A10 ../resources/mods/*/ModTheSpire.json
+
+# 2. 验证代码中的资源路径前缀是否匹配
+grep -rh "Resources/images" ../resources/mods --include="*.java" | grep -h "loadAnimation\|loadImage"
+```
+
+---
+
+## 2. 能量球 (Orb) 相关
+
+### 2.1 orbTextures/orbVfxPath 传 null 导致复用原版资源
+
+**现象**：
+- 自定义角色使用了铁甲师的红色能量球
+- 传入 null 后使用了默认的红色能量球样式
+
+**根因**：
+- `CustomEnergyOrb` 构造函数在 `orbTexturePaths == null` 时回退到 `ImageMaster.ENERGY_RED_*`
+- 代码第 38-52 行的 null 处理逻辑
+
+**推荐做法**：
+```java
+// 如果你确实想复用原版能量球（占位阶段）
+super(name, playerClass,
+    (String[])null,  // orbTextures
+    null,            // orbVfxPath
+    (String)null, (String)null);
+
+// 正式版应提供完整资源
+private static final String[] ORB_TEXTURES = new String[] {
+    "ModResources/images/char/orb/layer1.png",
+    "ModResources/images/char/orb/layer2.png",
+    "ModResources/images/char/orb/layer3.png",
+    "ModResources/images/char/orb/layer4.png",
+    "ModResources/images/char/orb/layer5.png",
+    "ModResources/images/char/orb/layer6.png",
+    "ModResources/images/char/orb/layer1d.png",
+    "ModResources/images/char/orb/layer2d.png",
+    "ModResources/images/char/orb/layer3d.png",
+    "ModResources/images/char/orb/layer4d.png",
+    "ModResources/images/char/orb/layer5d.png"
+};
+super(name, playerClass, ORB_TEXTURES, "ModResources/images/char/orb/vfx.png", LAYER_SPEED, ...);
+```
+
+**证据指针**：
+- `BaseMod/basemod/abstracts/CustomEnergyOrb.java:38-52` - null 处理逻辑
+- `LingMod/lingmod/character/Ling.java:65` - 传入 `(String)null, (String)null)` 复用原版
+
+**自检清单**：
+```bash
+# 1. 检查是否传入了 null
+grep -rn "orbTextures.*null\|orbVfxPath.*null" ../resources/mods --include="*.java"
+
+# 2. 运行游戏检查能量球颜色
+# 角色选择界面，能量球应显示为自定义颜色而非红色
+```
+
+---
+
+### 2.2 layer1..6d 资源缺失导致渲染异常
+
+**现象**：
+- 能量球有能量时正常，无能量时显示白色方块或消失
+- 报错 `Texture not found` 或渲染错乱
+
+**根因**：
+- `orbTextures` 数组长度应为奇数（中间是 base，前后对称）
+- 缺少无能量状态的层（带 d 后缀的文件）
+
+**推荐做法**：
+```java
+// 正确的数组结构：[enabled1..5, base, disabled1..5]
+// 总共 11 个元素（5层+base+5层）
+private static final String[] ORB_TEXTURES = new String[] {
+    // 有能量状态（5层）
+    "layer1.png", "layer2.png", "layer3.png", "layer4.png", "layer5.png",
+    // 基础层（1层，中间）
+    "layer6.png",
+    // 无能量状态（5层，带 d）
+    "layer1d.png", "layer2d.png", "layer3d.png", "layer4d.png", "layer5d.png"
+};
+```
+
+**证据指针**：
+- `BaseMod/basemod/abstracts/CustomEnergyOrb.java:22-25` - 长度和奇数校验
+- `Downfall/sneckomod/TheSnecko.java:35` - 完整的 11 层数组
+
+**自检清单**：
+```bash
+# 1. 检查 orbTextures 数组长度是否为奇数
+grep -A1 "orbTextures.*\[\]" ../resources/mods --include="*.java" | grep -c "new String\[\]"
+
+# 2. 验证资源文件是否完整
+ls ModResources/images/char/orb/{layer{1..5}.png,layer6.png,layer{1..5}d.png}
+```
+
+---
+
+### 2.3 layerSpeeds 数组长度不匹配
+
+**现象**：
+- 能量球动画速度异常
+- 报错 `ArrayIndexOutOfBoundsException`
+
+**根因**：
+- `layerSpeeds` 长度必须等于 `orbTextures.length / 2`（层数）
+- 默认 5 层需要 5 个速度值
+
+**推荐做法**：
+```java
+// 5层动画需要5个速度值
+private static final float[] LAYER_SPEED = new float[] {
+    -20.0F,   // layer1 逆时针
+    20.0F,    // layer2 顺时针
+    -40.0F,   // layer3 快速逆时针
+    40.0F,    // layer4 快速顺时针
+    360.0F    // layer5 特效层旋转
+};
+```
+
+**证据指针**：
+- `BaseMod/basemod/abstracts/CustomEnergyOrb.java:55-62` - 默认值和校验
+- `AnonMod/characters/char_Anon.java:48` - 完整的 10 元素速度数组
+
+**自检清单**：
+```bash
+# 1. 检查 LAYER_SPEED 数组长度是否为 (ORB_TEXTURES.length / 2)
+grep -A10 "LAYER_SPEED" ../resources/mods --include="*.java" | grep "new float\[\]" -A10
+
+# 2. 观察能量球动画是否各层旋转速度协调
+```
+
+---
+
+## 3. 角色选择界面 (Character Select)
+
+### 3.1 ScreenShake 参数过强导致"抖动很久"
+
+**现象**：
+- 点击角色后屏幕剧烈震动，持续数秒
+- 影响视觉体验，玩家抱怨
+
+**根因**：
+- `ShakeIntensity.HIGH` 或 `ShakeDur.LONG` 参数过于极端
+- 未考虑屏幕分辨率和玩家舒适度
+
+**推荐做法**：
+```java
+// 推荐使用轻微震动
+@Override
+public void doCharSelectScreenSelectEffect() {
+    CardCrawlGame.sound.playA("SELECT_SOUND", MathUtils.random(-0.2F, 0.2F));
+    CardCrawlGame.screenShake.shake(
+        ShakeIntensity.LOW,   // 或 MED，避免 HIGH
+        ShakeDur.SHORT,       // 避免 LONG、VERY_LONG
+        false                 // forceReset 通常为 false
+    );
+}
+```
+
+**证据指针**：
+- `Downfall/sneckomod/TheSnecko.java:90` - 使用 `ShakeIntensity.LOW, ShakeDur.SHORT`
+- `Koishi/Koishi/characters/KoishiCharacter.java:87` - 同样的 LOW/SHORT 组合
+
+**自检清单**：
+```bash
+# 1. 检查是否使用了过激参数
+grep -rn "ShakeIntensity.HIGH\|ShakeDur.LONG\|ShakeDur.VERY_LONG" ../resources/mods --include="*.java"
+
+# 2. 实际点击角色观察震动效果是否自然
+```
+
+---
+
+### 3.2 选中效果/头像资源缺失
+
+**现象**：
+- 角色选择界面头像显示为黑色方块
+- 选中效果无响应或报错
+
+**根因**：
+- `initializeClass` 参数中的 shoulder1/shoulder2/corpse 路径错误
+- 资源文件不存在或路径大小写不匹配
+
+**推荐做法**：
+```java
+// 确保所有路径资源存在
+public static final String SHOULDER1 = ModPaths.makeCharPath("shoulder.png");
+public static final String SHOULDER2 = ModPaths.makeCharPath("shoulder2.png");
+public static final String CORPSE = ModPaths.makeCharPath("corpse.png");
+
+// 构造时验证
+if (Gdx.files.internal(SHOULDER1).exists()) {
+    this.initializeClass(null, SHOULDER1, SHOULDER2, CORPSE, getLoadout(), ...);
+} else {
+    logger.error("Character select resources missing!");
+}
+```
+
+**证据指针**：
+- `AnonMod/characters/char_Anon.java:42-44` - 定义 SELES_SHOULDER/SELES_CORPSE 常量
+- `LingMod/lingmod/character/Ling.java:51-52` - 使用 `ModCore.makeCharacterPath()`
+
+**自检清单**：
+```bash
+# 1. 检查 initializeClass 参数中的路径是否真实存在
+grep -h "initializeClass" ../resources/mods --include="*.java" -A1 | grep -o "\"[^\"]*shoulder[^\"]*\""
+
+# 2. 验证文件存在
+ls ModResources/images/char/{shoulder.png,shoulder2.png,corpse.png}
+```
+
+---
+
+### 3.3 loadAnimation 调用时机错误
+
+**现象**：
+- 角色模型不显示或显示默认姿势
+- 动画状态未初始化
+
+**根因**：
+- `loadAnimation` 未在构造函数中调用
+- `SpineAnimation` 的 atlasUrl/skeletonUrl 设置错误
+
+**推荐做法**：
+```java
+// 方式1：通过 CustomPlayer 构造函数自动调用
+public MyCharacter(String name, PlayerClass setClass) {
+    super(name, setClass, orbTextures, orbVfx, new SpineAnimation(
+        "ModResources/images/char/player.atlas",
+        "ModResources/images/char/player.json",
+        1.0F
+    ));
+    // CustomPlayer 构造函数会自动调用 loadAnimation
+}
+
+// 方式2：手动调用
+public void reloadAnimation() {
+    this.loadAnimation(atlasUrl, skeletonUrl, scale);
+    AnimationState.TrackEntry e = this.state.setAnimation(0, "Idle", true);
+    e.setTime(e.getEndTime() * MathUtils.random());
+}
+```
+
+**证据指针**：
+- `BaseMod/basemod/abstracts/CustomPlayer.java:76-79` - 自动调用 `loadAnimation`
+- `Downfall/sneckomod/TheSnecko.java:50-56` - 手动 `reloadAnimation` 方法
+
+**自检清单**：
+```bash
+# 1. 检查是否调用了 loadAnimation
+grep -rn "loadAnimation" ../resources/mods --include="*Character.java"
+
+# 2. 验证动画是否显示
+# 运行游戏，观察角色模型是否有待机动画
+```
+
+---
+
+## 4. TopPanel / Tooltip
+
+### 4.1 tooltip 坐标硬编码导致画到屏幕外
+
+**现象**：
+- 鼠标悬停时 tooltip 不显示
+- 或显示位置偏移，部分在屏幕外
+
+**根因**：
+- `TipHelper.renderGenericTip` 使用了固定坐标
+- 未考虑 `Settings.scale` 缩放因子
+- 不同分辨率下坐标偏移
+
+**推荐做法**：
+```java
+// 错误示例：硬编码坐标
+TipHelper.renderGenericTip(1500.0F, 700.0F, title, body);  // 1080p 可能超出
+
+// 正确做法：使用相对坐标 + Settings.scale
+protected void onHover() {
+    if (this.hitbox.hovered) {
+        float tipX = 1550.0F * Settings.scale;  // 右侧固定位置
+        float tipY = (Settings.HEIGHT - 120.0F) * Settings.scale;  // 顶部偏移
+        TipHelper.renderGenericTip(tipX, tipY, TEXT[0], TEXT[1]);
+    }
+}
+```
+
+**证据指针**：
+- `LingMod/lingmod/ui/PoetryTopPanel.java:168` - 使用 `Settings.scale` 缩放坐标
+- `KeyCuts/test447/keycuts/patches/ProceedButtonPatches.java:73` - 动态计算 x - 140.0F * Settings.scale
+
+**自检清单**：
+```bash
+# 1. 检查是否使用了 Settings.scale
+grep -rn "renderGenericTip" ../resources/mods --include="*.java" | grep -v "Settings.scale"
+
+# 2. 在不同分辨率测试（1920x1080, 2560x1440, 3840x2160）
+```
+
+---
+
+### 4.2 TipHelper.renderGenericTip 不展开 NL
+
+**现象**：
+- tooltip 文本中的 `\n` 显示为字面量而非换行
+- 文本显示为单行，超出屏幕
+
+**根因**：
+- `TipHelper.renderGenericTip` 不会自动处理换行符
+- 需要手动分段或使用其他 API
+
+**推荐做法**：
+```java
+// 方式1：使用 TipHelper.renderTopPanelTip（支持自动换行）
+// 需要通过 patch 访问
+
+// 方式2：手动换行（推荐）
+String[] paragraphs = new String[] {
+    "第一段内容",
+    "第二段内容",
+    "第三段内容"
+};
+TipHelper.renderGenericTip(x, y, paragraphs[0], paragraphs[1] + " " + paragraphs[2]);
+
+// 方式3：使用 SmartTextHelper 或 BaseMod 的扩展 API
+```
+
+**证据指针**：
+- `KeyCuts/test447/keycuts/patches/ProceedButtonPatches.java:70-73` - 使用 UIStrings.TEXT 数组避免硬编码
+- `LingMod/lingmod/ui/PoetryTopPanel.java:168` - 使用预定义的 TEXT[0], TEXT[1]
+
+**自检清单**：
+```bash
+# 1. 检查 tooltip 内容中是否包含 \n 字面量
+grep -rn "renderGenericTip.*\\\\n" ../resources/mods --include="*.java"
+
+# 2. 验证 tooltip 文本是否正确换行显示
+```
+
+---
+
+### 4.3 updateTips 回调顺序问题
+
+**现象**：
+- 自定义 TopPanel 的 tooltip 显示延迟或不显示
+- 与原版 TopPanel 交互异常
+
+**根因**：
+- `onHover()` 调用时机晚于原版渲染
+- 未正确覆盖 `updateTips()` 回调
+
+**推荐做法**：
+```java
+// TopPanelItem 中正确实现 onHover
+@Override
+protected void onHover() {
+    super.onHover();  // 先调用父类
+    if (this.hitbox.hovered) {
+        TipHelper.renderGenericTip(...);
+    }
+}
+
+// 确保 updateTips 在正确的渲染阶段调用
+// BaseMod 会自动处理 TopPanelGroup 的渲染顺序
+```
+
+**证据指针**：
+- `LingMod/lingmod/ui/PoetryTopPanel.java:161-171` - 完整的 `onHover` 实现
+- `BaseMod/basemod/TopPanelItem.java` - 基类定义
+
+**自检清单**：
+```bash
+# 1. 检查是否调用了 super.onHover()
+grep -A5 "protected void onHover()" ../resources/mods --include="*TopPanel*.java"
+
+# 2. 观察自定义 TopPanel 与原版 TopPanel 的交互是否正常
+```
+
+---
+
+## 5. 占位复用原版资源的边界
+
+### 5.1 安全的行为（视觉层面）
+
+以下复用原版资源的行为在占位阶段是**可接受**的：
+
+| 复用内容 | 示例 | 风险评估 |
+|---------|------|---------|
+| 能量球纹理 | `orbTextures=null`, `orbVfxPath=null` | 低：仅视觉效果 |
+| 字体 | `FontHelper.energyNumFontRed` | 低：仅视觉效果 |
+| 动画占位 | `new SpriterAnimation(path)` 使用原版路径 | 低：临时占位 |
+
+**推荐做法**：
+```java
+// 占位阶段明确标注 TODO
+public MyCharacter(String name, PlayerClass setClass) {
+    // TODO: 替换为自定义能量球资源
+    super(name, setClass, (String[])null, null, ...);
+}
+
+// 提供回退配置
+private static final boolean USE_PLACEHOLDER = true;
+public BitmapFont getEnergyNumFont() {
+    return USE_PLACEHOLDER ? FontHelper.energyNumFontRed : customFont;
+}
+```
+
+**证据指针**：
+- `LingMod/lingmod/character/Ling.java:239` - 复用 `energyNumFontRed`
+- `ArknightsTheSpire/.../CharacterW.java:124` - 同样复用原版字体
+
+**自检清单**：
+```bash
+# 1. 检查是否有 TODO 标记占位代码
+grep -rn "TODO.*能量球\|TODO.*orb\|TODO.*font" ../resources/mods --include="*.java"
+```
+
+---
+
+### 5.2 危险的行为（影响未来重构）
+
+以下复用原版资源的行为是**危险**的，可能导致 mod 冲突或原版更新后崩溃：
+
+| 复用内容 | 示例 | 风险 | 影响 |
+|---------|------|------|------|
+| CardColor 枚举 | `return CardColor.RED;` | 高：与铁甲师冲突 | 无法区分卡牌 |
+| 原版枚举值 | `PlayerClass.IRONCLAD` | 高：破坏角色系统 | 崩溃/数据损坏 |
+| 资源测试断言 | 依赖原版资源路径存在 | 中：原版更新后失效 | 加载失败 |
+
+**推荐做法**：
+```java
+// 错误示例：复用 CardColor 枚举
+@Override
+public AbstractCard.CardColor getCardColor() {
+    return CardColor.RED;  // 危险！会与铁甲师混用卡池
+}
+
+// 正确做法：使用 SpireEnum 创建自定义枚举
+@SpireEnum
+public static AbstractPlayer.PlayerClass MY_CHARACTER;
+@SpireEnum
+public static AbstractCard.CardColor MY_COLOR;
+
+@Override
+public AbstractCard.CardColor getCardColor() {
+    return MY_COLOR;  // 安全，独立的卡池
+}
+```
+
+**证据指针**：
+- `Kikuchiyo/kikuchiyo/character/Kikuchiyo.java:108` - **危险示例**：直接返回 `CardColor.RED`
+- `BaseMod/basemod/abstracts/CustomPlayer.java:119-130` - 正确使用 `this.getCardColor()` 获取卡池
+
+**自检清单**：
+```bash
+# 1. 检查是否直接返回原版 CardColor
+grep -rn "return CardColor\.RED\|return CardColor\.BLUE\|return CardColor\.GREEN" ../resources/mods --include="*Character.java"
+
+# 2. 检查是否使用了 @SpireEnum 创建自定义枚举
+grep -rn "@SpireEnum" ../resources/mods --include="*.java" | grep -i "enum\|class\|color"
+```
+
+---
+
+### 5.3 复用资源的迁移路径
+
+当准备从占位迁移到自定义资源时：
+
+```java
+// 阶段1：占位（开发初期）
+public MyCharacter(String name, PlayerClass setClass) {
+    super(name, setClass, (String[])null, null, ...);
+}
+
+// 阶段2：混合（测试期间）
+public MyCharacter(String name, PlayerClass setClass) {
+    super(name, setClass,
+        "ModResources/images/char/orb/vfx.png",  // 仅提供 vfx
+        null,  // 其他纹理仍占位
+        ...
+    );
+}
+
+// 阶段3：完整（正式发布）
+public MyCharacter(String name, PlayerClass setClass) {
+    super(name, setClass, ORB_TEXTURES, ORB_VFX, LAYER_SPEED, ...);
+}
+
+// 清理检查清单：
+// [ ] 移除所有 (String)null 占位参数
+// [ ] 删除 USE_PLACEHOLDER 等开关变量
+// [ ] 删除 TODO 注释
+// [ ] 验证所有自定义资源文件存在
+// [ ] 测试不同分辨率下的显示效果
+```
+
+---
+
+## 附录：快速诊断命令
+
+```bash
+# 1. 检查所有 CustomPlayer 子类的资源路径
+grep -rn "extends CustomPlayer" ../resources/mods --include="*.java" | \
+  cut -d: -f1 | sort -u | \
+  xargs grep -h "loadAnimation\|ORB_TEXTURES\|SHOULDER"
+
+# 2. 查找所有潜在的硬编码坐标
+grep -rn "renderGenericTip.*[0-9]\+\.[0-9]\+F" ../resources/mods --include="*.java" | \
+  grep -v "Settings.scale"
+
+# 3. 检查 ScreenShake 参数使用
+grep -rn "screenShake.shake" ../resources/mods --include="*.java" | \
+  grep -E "HIGH|LONG|VERY_LONG"
+
+# 4. 查找复用原版 CardColor 的危险行为
+grep -rn "return CardColor\." ../resources/mods --include="*.java" | \
+  grep -v "getCardColor()" | grep "return"
+
+# 5. 验证 atlas/json 配对
+find ../resources/mods -name "*.atlas" | while read f; do
+  json="${f%.atlas}.json"
+  [ ! -f "$json" ] && echo "Unpaired: $f"
+done
+```
+
+---
+
+## 相关文档
+
+- [patching-pitfalls.md](./patching-pitfalls.md) - 修补相关坑点
+- [localization-ids-prefs-pitfalls.md](./localization-ids-prefs-pitfalls.md) - 本地化和配置坑点

--- a/docs/investigation-report.md
+++ b/docs/investigation-report.md
@@ -1,0 +1,183 @@
+# STS Mod 开发踩坑调研报告
+
+> 生成时间：2026-01-13
+> 数据来源：`../resources/mods/`（119 个解包 mod）、`docs/pitfalls.md`
+
+---
+
+## 1) 缺口总结（对照 `docs/pitfalls.md`）
+
+| 现有 9 条 | 本次可补充的新维度 |
+|-----------|-------------------|
+| 资源目录命名、ScreenShake、Orb 资源复用、卡色复用、gh PR 坑、TopPanel tooltip、TipHelper NL、Javassist `$0` | **CustomPlayer 骨架模式**、**@SpireEnum 自定义枚举**、**SpireConfig 跨存档持久化**、**Localization 多语言热加载**、**Patching 兼容性**、**ModTheSpire.json 依赖声明** |
+
+**结论**：`docs/pitfalls.md` 主要是"开发/构建/调试"层面的坑。**系统级功能**（卡色/角色/存档/多语言）几乎是空白。
+
+---
+
+## 2) 调查维度表
+
+| 维度 | 目的 | 关键问题 |
+|------|------|----------|
+| **语言 & 构建** | 判断模组技术栈 | 用 Java 还是 Kotlin？Gradle 还是 Maven？依赖 BaseMod/StSLib？ |
+| **CustomPlayer** | 角色实现骨架 | 怎么注册？能量球/卡色怎么处理？`doCharSelectScreenSelectEffect`？ |
+| **@SpirePatch** | 代码注入策略 | patch 哪些类？用 `cls` 还是 `expr`？patch 顺序冲突怎么处理？ |
+| **@SpireEnum** | 自定义枚举扩展 | 自定义 `CardColor` / `RelicTier` / `LibraryType`？如何配合 `BaseMod.addColor`？ |
+| **Localization** | 多语言文案 | 用哪种语言文件格式？`CardStrings`/`RelicStrings`？热更新还是重启生效？ |
+| **SpireConfig** | 用户设置/存档 | 怎么注册？`saveSpecial`/`saveString` 在哪里写？怎么避免存档膨胀？ |
+| **Resources & Packaging** | 资源打包 | 贴图/Spine/音效放哪？`ModTheSpire.json` 的 `resources` 字段怎么配？ |
+| **Dependencies** | 依赖管理 | 是否依赖 BaseMod/StSLib/Downfall？版本声明怎么写？ |
+
+---
+
+## 3) 代表 Mod 列表（30 个，覆盖全维度）
+
+| Mod 名 | 推荐理由 |
+|--------|----------|
+| **LingMod** | 本地参考标杆，Java + Maven，角色/卡牌/遗物/UI 全覆盖 |
+| **BaseMod** | 基础设施级，所有 Patch/Enum/Config 最佳实践源头 |
+| **StSLib** | Patch-heavy 代表，`@SpirePatch` 复杂用法（MultiUpgrade、BranchingUpgrades） |
+| **Downfall** | 超大型模组，跨模组兼容性、资源打包、多语言、存档管理参考 |
+| **DuskMod** | 中型 Java 模组，角色实现简洁 |
+| **ReimuMod** | 多角色/多卡色，@SpireEnum 完整示例（ClassEnum、LibraryTypeEnum、CardTagEnum） |
+| **Lobotomy** | 大量自定义 Enum（CharacterEnum、RelicTierEnum），大量 Patch |
+| **YogSothothMod** | 多角色分目录，存档管理（`saveSpecial`）参考 |
+| **hsr-mod** | Kotlin + Gradle，现代模组配置 |
+| **FrierenMod** | 多角色 + 多卡色，SpireConfig 典型用法 |
+| **KaltsitMod** | 大型二次元模组，资源打包、Spine 集成参考 |
+| **ArknightsTheSpire** | 多角色 + 多职业，UI 扩展、Config 参考 |
+| **ThePackmaster** | 卡牌包模组，CardColor 扩展 + 自定义 Enum |
+| **LogosMod** | 大型模组，Patch 冲突处理、兼容性写法参考 |
+| **AcaciaTheSpire** | 中型模组，Java 风格规范，ModTheSpire.json 完整示例 |
+| **Tenshi** | 角色实现 + 简单 UI，入门参考 |
+| **Mizuki** | 角色 + 遗物，SpireConfig 简单用法 |
+| **AetherMod** | 早期模组，对比新式模组看演进 |
+| **MuseDashReskin** | Patch-heavy，特定系统注入 |
+| **intentgraph** | UI 扩展、屏幕自定义，Resources 打包参考 |
+| **DeckTracker** | UI/功能模组，SpireConfig + Patch 组合 |
+| **TheColorful** | 角色实现，代码结构简洁 |
+| **Koishi** | 多角色 + 卡牌，Enum + Config 参考 |
+| **RemiliaScarlet** | Enum 完整示例（多个 Enum 文件） |
+| **Keinemod** | 角色 + 卡牌，基础用法典范 |
+| **BlackRuseMod** | 角色实现 + Patch 参考 |
+| **SovietMod** | ModTheSpire.json 示例（dependencies） |
+| **Reed-1.0-SHALL** | UI 扩展、皮肤选择屏幕 |
+| **Elaina** | 二次元模组，角色/卡牌/UI 综合示例 |
+| **IbukiSuika** | 角色 + 简单功能，入门参考 |
+
+---
+
+## 4) 证据采集命令清单
+
+### 4.1 CustomPlayer 骨架
+```bash
+# 查找所有 CustomPlayer 实现
+rg -g "*.java" -g "*.kt" "extends CustomPlayer|: CustomPlayer\(" ../resources/mods -l
+
+# 典型写法对照（看 ScreenShake 参数）
+rg "doCharSelectScreenSelectEffect" ../resources/mods/LingMod -A 5
+
+# Orb 资源传参
+rg "orbTextures|orbVfxPath" ../resources/mods/LingMod -A 2
+```
+
+### 4.2 @SpirePatch 模式
+```bash
+# Patch-heavy 模组列表
+rg -g "*.java" -g "*.kt" "@SpirePatch" ../resources/mods -l | head -20
+
+# Patch 类写法（cls vs expr）
+rg "@SpirePatch\(cls" ../resources/mods/BaseMod -l | head -5
+rg "@SpirePatch\(expr" ../resources/mods/StSLib -l | head -5
+
+# Patch 冲突/顺序处理
+rg "SpireInsert\(|SpireReplace\(" ../resources/mods/StSLib -l
+```
+
+### 4.3 @SpireEnum + 自定义卡色
+```bash
+# 自定义 CardColor 的 Enum
+rg "@SpireEnum" ../resources/mods/ReimuMod -l
+rg "BaseMod.addColor" ../resources/mods/ReimuMod -B 2 -A 5
+
+# LibraryTypeEnum 对应
+rg "LibraryTypeEnum" ../resources/mods/Lobotomy -l
+```
+
+### 4.4 Localization 多语言
+```bash
+# 有 localization 目录的模组
+rg -g "*.json" "\"localization\"" ../resources/mods -l
+
+# 多语言目录结构
+ls -la ../resources/mods/Downfall/hexamodResources/localization/
+
+# CardStrings/RelicStrings 写法
+rg "\"DESCRIPTION\"" ../resources/mods/Downfall/hexamodResources/localization/eng/CardStrings.json | head -5
+```
+
+### 4.5 SpireConfig & Save
+```bash
+# SpireConfig 注册
+rg "new SpireConfig" ../resources/mods -l | head -10
+
+# saveString / saveSpecial 用法
+rg "saveString|saveSpecial" ../resources/mods/StSLib -l
+rg "abstractSaveString|abstractSaveSpecial" ../resources/mods/BaseMod -l
+
+# Config UI 绑定
+rg "setShowPopup\(|setPopupText\(" ../resources/mods/hsr-mod -l
+```
+
+### 4.6 ModTheSpire.json & 依赖
+```bash
+# 依赖声明示例
+cat ../resources/mods/AcaciaTheSpire/ModTheSpire.json
+cat ../resources/mods/hsr-mod/ModTheSpire.json
+
+# resources 字段配置
+rg "\"resources\"" ../resources/mods/Downfall/ModTheSpire.json -A 5
+```
+
+### 4.7 Resources & 打包
+```bash
+# 资源目录结构
+ls -la ../resources/mods/intentgraph/io/chaofan/sts/intentgraph/
+
+# Spire 资源路径引用
+rg "CardCrawlFiles\\.resource" ../resources/mods/LingMod -l
+```
+
+---
+
+## 5) Heatmap & 深挖优先级
+
+| 主题 | 频次 | 踩坑风险 | 深挖理由 |
+|------|------|---------|----------|
+| **@SpirePatch** | ★★★★★ (115/30/25) | 高 | Patch 冲突/顺序是最常见崩溃原因 |
+| **CustomPlayer** | ★★★★☆ (~90) | 中 | 角色入口，能量球/卡色/UI 都在此汇聚 |
+| **@SpireEnum + CardColor** | ★★★★☆ (~50) | 高 | 卡色独立是"完全自洽模组"的分水岭 |
+| **SpireConfig** | ★★★☆☆ (~103) | 中 | 存档持久化、回档兼容、用户设置 |
+| **Localization** | ★★☆☆☆ (~10 有目录) | 中 | 多语言热更新、占位符替换 |
+| **Resources & Packaging** | ★★☆☆☆ (差异大) | 低~中 | 路径错误只会导致资源不显示 |
+
+### 优先深挖主题（TOP 3）
+
+1. **@SpirePatch** — 证据最多，Patch 冲突是社区高频问题
+2. **@SpireEnum + CardColor** — "完全独立角色"必经之路
+3. **SpireConfig & Save** — 存档兼容性影响长期体验
+
+---
+
+## 附录：关键 Mod 文件路径速查
+
+| Mod | 关键文件路径 |
+|-----|-------------|
+| LingMod | `lingmod/ModCore.java`、`lingmod/character/Ling.java` |
+| BaseMod | `basemod/patches/...`（大量 Patch 示例） |
+| StSLib | `com/evacipated/cardcrawl/mod/stslib/patches/...` |
+| ReimuMod | `ReimuMod/patches/ReimuClassEnum.java`、`characters/ReiMu.java` |
+| Lobotomy | `lobotomyMod/patch/CharacterEnum.java`、`patch/AbstractCardEnum.java` |
+| hsr-mod | `ModTheSpire.json`（dependencies 示例） |
+| AcaciaTheSpire | `ModTheSpire.json`、`characters/Acacia.java` |
+| Downfall | `hexamodResources/localization/`（多语言示例） |

--- a/docs/localization-ids-prefs-pitfalls.md
+++ b/docs/localization-ids-prefs-pitfalls.md
@@ -1,0 +1,746 @@
+# Localization、IDs、Prefs/Save 相关坑点
+
+> 面向 STS mod 工程师，聚焦多语言、ID 命名、配置持久化三大主题的常见陷阱。
+
+---
+
+## 目录
+
+1. [Localization 多语言](#1-localization-多语言)
+2. [IDs 命名规范](#2-ids-命名规范)
+3. [SpireConfig & Save 持久化](#3-spireconfig--save-持久化)
+4. [注册时机速查表](#4-注册时机速查表)
+5. [推荐目录结构](#5-推荐目录结构)
+
+---
+
+## 1. Localization 多语言
+
+### 1.1 加载时机错误
+
+#### 🔴 **坑点：在构造函数中调用 `loadCustomStringsFile`**
+
+**现象**：不会报错，但多语言文本无法加载，游戏内显示 `MISSING:` 或 ID。
+
+**根因**：`receiveEditStrings()` 回调的调用时机早于构造函数执行。在构造函数中加载的字符串会被后续的回调覆盖。
+
+**证据指针**：
+- ✅ **WljMod** (wlj-mod-1.3.4)：在 `receiveEditStrings()` 回调中加载本地化文件（行 173-206）
+- ✅ **AyaMod**：在 `receiveEditStrings()` 回调中加载本地化文件（行 274-285）
+- ❌ **错误示例**：在主类构造函数中直接调用 `BaseMod.loadCustomStringsFile()`
+
+**推荐做法**：
+```java
+public class MyMod implements EditStringsSubscriber {
+    public void receiveEditStrings() {
+        // ✓ 正确：在回调中加载
+        String lang = getLocalizationLanguage();
+        BaseMod.loadCustomStringsFile(CardStrings.class,
+            "localization/" + lang + "/my_cards.json");
+    }
+}
+```
+
+**自检清单**：
+- [ ] 所有 `loadCustomStringsFile` 调用都在 `receiveEditStrings()` 回调内
+- [ ] 没有在构造函数中直接调用本地化加载方法
+
+---
+
+### 1.2 UTF-8 编码问题
+
+#### 🔴 **坑点：JSON 文件未指定 UTF-8 编码读取**
+
+**现象**：中文、日文等多语言文本显示为乱码或方框。
+
+**根因**：`Gdx.files.internal().readString()` 默认使用系统编码，而非 UTF-8。
+
+**证据指针**：
+- ✅ **WljMod**（行 192）：`readString(String.valueOf(StandardCharsets.UTF_8))`
+- ✅ **AyaMod**（行 290）：`readString(String.valueOf(StandardCharsets.UTF_8))`
+- ✅ **AnonMod**（行 446）：`readString(String.valueOf(StandardCharsets.UTF_8))`
+
+**推荐做法**：
+```java
+// ✓ 正确：显式指定 UTF-8
+String json = Gdx.files.internal("localization/eng/my_keywords.json")
+    .readString(String.valueOf(StandardCharsets.UTF_8));
+```
+
+**自检清单**：
+- [ ] 所有 `readString()` 调用都显式传入 `StandardCharsets.UTF_8`
+
+---
+
+### 1.3 语言回退机制
+
+#### 🟡 **坑点：未处理不支持语言的回退**
+
+**现象**：游戏语言设置为 `POR`（葡萄牙语）时，找不到对应本地化文件，崩溃或显示 `MISSING:`。
+
+**根因**：仅提供了部分语言（如 `eng`、`zhs`、`zht`），未设置默认回退到 `eng`。
+
+**证据指针**：
+- ✅ **WljMod**（行 175-182）：使用 `switch(Settings.language)` 并 `default` 到 `zhs`
+- ✅ **AyaMod**（行 197-206）：使用 `switch` 并 `default` 到 `eng`
+- ⚠️ **AnonMod**（行 476）：使用 `if (Settings.language == GameLanguage.ZHS)` else 模式
+
+**推荐做法**：
+```java
+private String getLocalizationLanguage() {
+    switch (Settings.language) {
+        case ZHS: return "zhs";
+        case ZHT: return "zht";
+        case JPN: return "jpn";
+        // ... 其他支持的语言
+        default: return "eng"; // ✓ 默认回退到英文
+    }
+}
+```
+
+**自检清单**：
+- [ ] `switch` 语句包含 `default` 分支回退到 `eng`
+- [ ] 或使用 `if-else` 链并包含 `else` 默认值
+
+---
+
+### 1.4 Keywords 注册时机
+
+#### 🔴 **坑点：Keywords 在 `receiveEditStrings()` 中注册**
+
+**现象**：关键词提示文本显示为 ID 或 `MISSING:`。
+
+**根因**：`BaseMod.addKeyword()` 必须在 `receiveEditKeywords()` 回调中调用，而非 `receiveEditStrings()`。
+
+**证据指针**：
+- ✅ **WljMod**（行 149-156）：在 `receiveEditKeywords()` 中调用 `BaseMod.addKeyword()`
+- ✅ **AyaMod**（行 287-298）：在 `receiveEditKeywords()` 中调用 `BaseMod.addKeyword()`
+- ⚠️ **AnonMod**（行 449-464）：在 `receiveEditKeywords()` 中调用，但未使用 `@SpireEnum` 创建的前缀
+
+**推荐做法**：
+```java
+public void receiveEditKeywords() {
+    // 1. 先读取 JSON
+    String json = Gdx.files.internal("localization/" + lang + "/my_keywords.json")
+        .readString(String.valueOf(StandardCharsets.UTF_8));
+    Keyword[] keywords = new Gson().fromJson(json, Keyword[].class);
+
+    // 2. 在此回调中注册
+    for (Keyword keyword : keywords) {
+        BaseMod.addKeyword(
+            modID.toLowerCase(),  // ✓ 前缀
+            keyword.PROPER_NAME,
+            keyword.NAMES,
+            keyword.DESCRIPTION
+        );
+    }
+}
+```
+
+**自检清单**：
+- [ ] `addKeyword()` 调用位于 `receiveEditKeywords()` 回调内
+- [ ] 传入的第一个参数是 `modID.toLowerCase()`
+
+---
+
+### 1.5 ID 前缀规范
+
+#### 🔴 **坑点：ID 未使用 `modID:` 前缀**
+
+**现象**：与其他 mod 的 ID 冲突，导致卡牌/遗物描述错乱。
+
+**根因**：ID 必须全局唯一，使用 `modID:` 前缀是社区约定。
+
+**证据指针**：
+- ✅ **Downfall**：所有 ID 使用 `awakened:` 前缀（如 `awakened:Thunderbolt`）
+- ✅ **WljMod**：使用 `Wlj:` 前缀（如 `Wlj:Cup`）
+- ✅ **AyaMod**：使用 `theAya:` 前缀（如 `theAya:FlyingPotion`）
+- ✅ **HSRMod**：使用 `HSRMod:` 前缀（如 `HSRMod:Trailblazer1`）
+- ⚠️ **AnonMod**：部分 ID 未使用前缀（如 `Inner`、`liveboost`）
+
+**推荐做法**：
+```java
+// ✓ 在 JSON 中
+{
+  "MyMod:Strike": {
+    "NAME": "Strike",
+    "DESCRIPTION": "Deal !D! damage."
+  }
+}
+
+// ✓ 在代码中
+public static final String ID = "MyMod:Strike";
+```
+
+**自检清单**：
+- [ ] 所有 localization JSON 中的 key 都使用 `modID:` 前缀
+- [ ] Java 代码中的常量 ID 也使用相同前缀
+
+---
+
+### 1.6 NL 换行符展开问题
+
+#### 🟡 **坑点：混淆 `NL` 与 `\n`**
+
+**现象**：卡牌描述中的换行符不生效，显示为字面量 `NL` 或 `\n`。
+
+**根因**：
+- `NL` 是 STS 的特殊标记，会在运行时展开为 `\n`
+- 直接使用 `\n` 不会在描述中正确换行
+
+**证据指针**：
+- ✅ **Downfall**（CardStrings.json）：大量使用 `NL`（如 `"DESCRIPTION": "Retain. NL Deal !D! damage. NL Exhaust."`）
+- ✅ **HSRMod**（ui.json）：混合使用 `NL` 和普通文本
+
+**推荐做法**：
+```json
+// ✓ 正确：使用 NL 进行换行
+{
+  "MyMod:MyCard": {
+    "DESCRIPTION": "Gain !B! Block. NL Deal !D! damage. NL Exhaust."
+  }
+}
+
+// ✗ 错误：直接使用 \n
+{
+  "MyMod:MyCard": {
+    "DESCRIPTION": "Gain !B! Block.\nDeal !D! damage.\nExhaust."
+  }
+}
+```
+
+**自检清单**：
+- [ ] JSON 文件中的描述使用 ` NL ` 进行换行（前后有空格）
+- [ ] 仅在需要字面量 `\n` 时才使用转义符
+
+---
+
+## 2. IDs 命名规范
+
+### 2.1 与 @SpireEnum 的冲突风险
+
+#### 🔴 **坑点：Enum 值名与 Localization ID 混用**
+
+**现象**：使用 `@SpireEnum` 创建的 `CardColor`、`CardTags` 等的 `name()` 返回值可能作为 ID 使用，导致歧义。
+
+**根因**：
+- `@SpireEnum` 注解的静态字段在运行时会被赋予唯一名称
+- 但这个名称可能与手动指定的 localization ID 不一致
+
+**证据指针**：
+- ✅ **AnonMod**（CardTagsEnum.java）：使用 `@SpireEnum` 创建 `Band` tag
+- ✅ **LingMod**（ModEnums.java）：使用 `@SpireEnum` 创建多个枚举值
+- ⚠️ **常见错误**：将 `@SpireEnum` 字段名直接用于 localization key
+
+**推荐做法**：
+```java
+// ✓ 正确：明确区分 Enum 值和 Localization ID
+public class MyCardTags {
+    @SpireEnum
+    public static AbstractCard.CardTags MY_TAG;  // Enum 值
+}
+
+// JSON 中使用完整的 modID: 前缀
+{
+  "MyMod:MyCard": {
+    "DESCRIPTION": "Has #myModMyTag."
+  }
+}
+```
+
+**自检清单**：
+- [ ] Localization JSON 中的 ID 始终使用 `modID:` 前缀
+- [ ] 不依赖 `@SpireEnum` 字段的 `.name()` 返回值作为 localization key
+
+---
+
+### 2.2 推荐的 ID 命名风格
+
+#### 🟢 **最佳实践**：
+
+**格式**：`<modID>:<EntityName>`
+
+**示例**：
+- 卡牌：`MyMod:Strike`、`MyMod:Defend`
+- 遗物：`MyMod:BurningBlood`、`MyMod:Anchor`
+- 力量：`MyMod:Weakened`、`MyMod:Energized`
+- 药水：`MyMod:FirePotion`、`MyMod:StrengthPotion`
+
+**证据指针**：
+- ✅ **Downfall**：`awakened:Thunderbolt`、`awakened:Cryostasis`
+- ✅ **HSRMod**：`HSRMod:Trailblazer1`、`HSRMod:March7th0`
+- ✅ **WljMod**：`Wlj:Cup`、`Wlj:Frog`（Event ID）
+
+**命名约定**：
+1. **modID 部分**：与 ModTheSpire.json 中的 `modid` 字段完全一致（大小写敏感）
+2. **分隔符**：使用英文冒号 `:`（唯一合法分隔符）
+3. **实体名部分**：
+   - 使用 PascalCase（首字母大写）
+   - 避免特殊字符（仅字母、数字、下划线）
+   - 简洁但描述性强
+
+**自检清单**：
+- [ ] 所有 ID 遵循 `<modID>:<EntityName>` 格式
+- [ ] modID 与 ModTheSpire.json 中的定义一致
+- [ ] 实体名使用 PascalCase，无特殊字符
+
+---
+
+## 3. SpireConfig & Save 持久化
+
+### 3.1 SpireConfig 注册时机
+
+#### 🔴 **坑点：SpireConfig 创建时机不当**
+
+**现象**：
+- 情况 A：在 `initialize()` 静态方法中创建，但未正确加载配置
+- 情况 B：在 `receivePostInitialize()` 中创建，导致早期代码无法访问
+
+**根因**：`SpireConfig` 需要在 `initialize()` 或静态初始化块中创建并 `load()`，才能在后续回调中使用。
+
+**证据指针**：
+- ✅ **WljMod**（行 96-100）：在构造函数中创建 `SpireConfig`
+- ✅ **AnonMod**（行 1042-1045）：在静态初始化块中创建 `SpireConfig saves`
+- ✅ **AyaMod**（行 110-116）：在构造函数中创建并 `load()` 配置
+- ⚠️ **常见错误**：在 `receivePostInitialize()` 中创建配置
+
+**推荐做法**：
+```java
+@SpireInitializer
+public class MyMod {
+    public static SpireConfig config;
+
+    static {
+        try {
+            Properties defaults = new Properties();
+            defaults.setProperty("mySetting", "false");
+            config = new SpireConfig("MyMod", "MyModConfig", defaults);
+            config.load();  // ✓ 立即加载
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+    }
+
+    public static void initialize() {
+        new MyMod();
+    }
+}
+```
+
+**自检清单**：
+- [ ] `SpireConfig` 在静态初始化块或构造函数中创建
+- [ ] 创建后立即调用 `config.load()`
+- [ ] 不在 `receivePostInitialize()` 等回调中创建配置
+
+---
+
+### 3.2 getPrefs 时机与 lazy init
+
+#### 🟡 **坑点：过早访问未初始化的配置**
+
+**现象**：在 `receiveEditCards()` 等早期回调中访问 `config.getBool()`，返回值不正确或抛出异常。
+
+**根因**：虽然 `SpireConfig` 已创建，但某些配置项可能需要延迟加载（lazy init）。
+
+**证据指针**：
+- ✅ **WljMod**（行 83-89）：使用 `getVoiceDisabled()` 方法，内部检查 `config == null`
+- ⚠️ **常见错误**：直接在回调中访问 `config.getBool("someKey")`
+
+**推荐做法**：
+```java
+// ✓ 使用 getter 方法，提供默认值
+public static boolean isMyFeatureEnabled() {
+    if (config == null) {
+        return false;  // ✓ 安全默认值
+    }
+    try {
+        return config.getBool("myFeature");
+    } catch (Exception e) {
+        return false;
+    }
+}
+
+// ✓ 在需要时才调用
+public void receiveEditCards() {
+    if (isMyFeatureEnabled()) {
+        // 添加特定卡牌
+    }
+}
+```
+
+**自检清单**：
+- [ ] 所有配置访问都通过 getter 方法包装
+- [ ] getter 方法包含 `config == null` 检查
+- [ ] 提供合理的默认值
+
+---
+
+### 3.3 onSave/onLoad 实现
+
+#### 🔴 **坑点：CustomSavable 实现不完整**
+
+**现象**：
+- 存档中保存的数据无法正确恢复
+- 读取存档后游戏行为异常
+
+**根因**：`CustomSavable<T>` 接口需要正确实现 `onSave()` 和 `onLoad(T value)`。
+
+**证据指针**：
+- ✅ **GeniusSocietysDangerousGossip**（hsr-mod）：实现 `CustomSavable<Integer>`，保存 `goldGained`（行 56-64）
+- ✅ **Inner**（AnonMod）：实现 `CustomSavable<SoulHeartSave>`，但目前返回 `null`（行 34-39）
+- ⚠️ **常见错误**：`onSave()` 返回 `null`，导致无法保存数据
+
+**推荐做法**：
+```java
+public class MyRelic extends CustomRelic implements CustomSavable<MySaveData> {
+    private int myCounter = 0;
+
+    @Override
+    public MySaveData onSave() {
+        MySaveData data = new MySaveData();
+        data.counter = this.myCounter;
+        return data;  // ✓ 返回实际数据
+    }
+
+    @Override
+    public void onLoad(MySaveData data) {
+        if (data != null) {
+            this.myCounter = data.counter;  // ✓ 恢复数据
+        }
+    }
+}
+```
+
+**自检清单**：
+- [ ] `onSave()` 返回非 `null` 的有效数据
+- [ ] `onLoad()` 处理 `null` 输入的情况
+- [ ] 保存的数据类型是可序列化的（基本类型、POJO）
+
+---
+
+### 3.4 版本升级迁移
+
+#### 🟡 **坑点：配置结构变更导致旧存档失效**
+
+**现象**：mod 更新后，玩家存档无法加载，或配置项丢失。
+
+**根因**：`SpireConfig` 不会自动迁移旧配置到新格式。
+
+**推荐做法**：
+```java
+static {
+    try {
+        Properties defaults = new Properties();
+        defaults.setProperty("version", "2.0");
+        defaults.setProperty("newFeature", "false");
+        config = new SpireConfig("MyMod", "MyModConfig", defaults);
+        config.load();
+
+        // ✓ 版本检查与迁移
+        String version = config.getString("version");
+        if ("1.0".equals(version)) {
+            migrateFromV1ToV2();
+        }
+    } catch (IOException e) {
+        e.printStackTrace();
+    }
+}
+
+private static void migrateFromV1ToV2() {
+    // 迁移旧配置
+    boolean oldSetting = config.getBool("oldSettingName");
+    config.setBool("newSettingName", oldSetting);
+    config.setString("version", "2.0");
+    config.save();
+}
+```
+
+**自检清单**：
+- [ ] 配置文件中包含版本号字段
+- [ ] 在加载后检查版本号并执行迁移
+- [ ] 迁移后调用 `config.save()` 保存
+
+---
+
+### 3.5 存档膨胀问题
+
+#### 🟡 **坑点：过度保存导致存档文件过大**
+
+**现象**：存档文件异常庞大，加载/保存速度变慢。
+
+**根因**：每次保存都写入大量数据，或保存了冗余信息。
+
+**证据指针**：
+- ✅ **AnonMod**（SavemetricData.java）：使用独立的 SpireConfig (`sp-racing`, `saves`) 存储统计数据
+- ⚠️ **常见错误**：在 `onSave()` 中保存整个对象图
+
+**推荐做法**：
+```java
+// ✓ 只保存必要数据
+@Override
+public Integer onSave() {
+    return this.myCounter;  // 仅保存一个 int
+}
+
+// ✗ 避免：保存大量数据
+@Override
+public Map<String, Object> onSave() {
+    Map<String, Object> data = new HashMap<>();
+    data.put("entireHistory", this.history);  // 可能有数千条记录
+    return data;
+}
+```
+
+**自检清单**：
+- [ ] 保存的数据尽可能精简（基本类型优先）
+- [ ] 避免保存大型集合或对象图
+- [ ] 考虑使用独立文件存储统计数据
+
+---
+
+### 3.6 abstractSaveString/abstractSaveSpecial 使用场景
+
+#### 🟢 **何时使用**：
+
+**`abstractSaveString()`**：
+- 需要自定义序列化逻辑
+- 数据格式复杂（嵌套对象）
+- 需要与其他 mod 交互
+
+**`abstractSaveSpecial()`**：
+- 需要保存到特殊位置（非玩家存档）
+- 跨 run 持久化数据
+
+**推荐做法**：
+```java
+// ✓ 使用自定义序列化
+@Override
+public String onSave() {
+    return myCounter + ":" + myFlag;  // 自定义格式
+}
+
+@Override
+public void onLoad(String data) {
+    if (data != null && data.contains(":")) {
+        String[] parts = data.split(":");
+        this.myCounter = Integer.parseInt(parts[0]);
+        this.myFlag = Boolean.parseBoolean(parts[1]);
+    }
+}
+```
+
+**自检清单**：
+- [ ] 仅在默认序列化不满足需求时使用自定义方法
+- [ ] 自定义格式包含版本标识（便于迁移）
+
+---
+
+## 4. 注册时机速查表
+
+| 操作 | 推荐时机 (Mod lifecycle) | 注意事项 | 证据来源 |
+|------|-------------------------|---------|---------|
+| **BaseMod.addColor** | 主类构造函数 | 必须在 `receiveEditCharacters()` 之前 | WljMod (行 94), AyaMod (行 105) |
+| **BaseMod.addCharacter** | `receiveEditCharacters()` 回调 | 需确保 color 已注册 | WljMod (行 142), AyaMod (行 213) |
+| **BaseMod.addLocalization / loadCustomStringsFile** | `receiveEditStrings()` 回调 | ❌ 不在构造函数中调用 | WljMod (行 173), AyaMod (行 274) |
+| **BaseMod.addKeyword** | `receiveEditKeywords()` 回调 | ❌ 不在 `receiveEditStrings()` 中调用 | WljMod (行 149), AyaMod (行 287) |
+| **BaseMod.addCard / AutoAdd** | `receiveEditCards()` 回调 | 确保 strings 已加载 | WljMod (行 135), AyaMod (行 262) |
+| **BaseMod.addRelic** | `receiveEditRelics()` 回调 | 确保 color 已注册 | WljMod (行 158), AyaMod (行 251) |
+| **new SpireConfig** | 静态初始化块或构造函数 | 立即调用 `load()` | AnonMod (行 1042), AyaMod (行 110) |
+| **config.save()** | 配置变更后立即调用 | 避免丢失设置 | WljMod (行 122), AyaMod (行 229) |
+| **CustomSavable.onSave** | 游戏自动调用（存档时） | 返回非 null 数据 | HSRMod GeniusSocietysDangerousGossip (行 56) |
+| **CustomSavable.onLoad** | 游戏自动调用（读档时） | 处理 null 输入 | HSRMod GeniusSocietysDangerousGossip (行 61) |
+| **BaseMod.registerModBadge** | `receivePostInitialize()` 回调 | 创建设置面板 | WljMod (行 129), AyaMod (行 236) |
+| **BaseMod.addEvent** | `receivePostInitialize()` 回调 | 确保 strings 已加载 | WljMod (行 130-131) |
+| **BaseMod.addMonster / addBoss** | `receivePostInitialize()` 回调 | 确保 monster strings 已加载 | AnonMod (行 740-813) |
+
+### 关键原则
+
+1. **顺序依赖**：
+   - Color → Character/Relic
+   - Strings → Cards/Relics/Powers
+   - Config → Settings Panel
+
+2. **时机规则**：
+   - 资源注册（Color/Character）：构造函数
+   - 内容编辑（Cards/Relics/Strings）：对应回调
+   - UI 元素（Badge/Panel）：PostInitialize
+
+3. **避免的时序错误**：
+   - ❌ 在构造函数中调用 `loadCustomStringsFile()`
+   - ❌ 在 `receiveEditStrings()` 中调用 `addKeyword()`
+   - ❌ 在 `receivePostInitialize()` 中创建 `SpireConfig`
+
+---
+
+## 5. 推荐目录结构
+
+### 5.1 社区主流结构
+
+基于 **Downfall**、**WljMod**、**AyaMod**、**HSRMod** 的观察：
+
+```
+MyMod/
+├── ModTheSpire.json              # Mod 元数据
+├── src/
+│   └── com/
+│       └── mymod/
+│           ├── MyMod.java        # 主类 (@SpireInitializer)
+│           ├── cards/
+│           ├── relics/
+│           ├── powers/
+│           ├── characters/
+│           └── util/
+├── resources/                     # 或直接放在 mod 根目录
+│   ├── localization/             # ✓ 多语言目录
+│   │   ├── eng/
+│   │   │   ├── cards.json
+│   │   │   ├── relics.json
+│   │   │   ├── powers.json
+│   │   │   ├── keywords.json
+│   │   │   └── ...
+│   │   ├── zhs/
+│   │   │   └── ... (同 eng 结构)
+│   │   ├── zht/
+│   │   ├── jpn/
+│   │   └── kor/
+│   ├── images/
+│   │   ├── cards/
+│   │   ├── relics/
+│   │   ├── powers/
+│   │   ├── characters/
+│   │   └── ui/
+│   └── audio/
+└── README.md
+```
+
+### 5.2 结构规范
+
+#### Localization 文件命名
+
+**推荐命名**（参考 Downfall）：
+- `cards.json`（或 `CardStrings.json`）
+- `relics.json`（或 `RelicStrings.json`）
+- `powers.json`（或 `PowerStrings.json`）
+- `keywords.json`（或 `KeywordStrings.json`）
+- `events.json`
+- `potions.json`
+- `monsters.json`
+- `characters.json`
+- `ui.json`
+
+**证据指针**：
+- ✅ **Downfall**：使用标准类型名（`CardStrings.json`）
+- ✅ **WljMod**：使用简短名称（`wlj_cards.json`）
+- ✅ **AnonMod**：使用带语言后缀的名称（`Anon_cards-zh.json`）
+
+#### Resources 目录布局
+
+**选项 A**：ModID + Resources（推荐）
+```
+MyModResources/
+├── localization/
+├── images/
+└── audio/
+```
+
+**选项 B**：直接使用 modID
+```
+mymod/
+├── localization/
+├── images/
+└── audio/
+```
+
+**选项 C**：平铺结构（AyaMod 风格）
+```
+theAyaResources/
+└── localization/
+```
+
+### 5.3 文件路径引用
+
+**推荐做法**：
+```java
+// ✓ 使用常量避免硬编码
+public class MyMod {
+    public static final String MOD_ID = "MyMod";
+    public static final String RESOURCES_FOLDER = MOD_ID + "Resources";
+
+    public static String makeCardPath(String resourcePath) {
+        return RESOURCES_FOLDER + "/images/cards/" + resourcePath;
+    }
+
+    public static String makeRelicPath(String resourcePath) {
+        return RESOURCES_FOLDER + "/images/relics/" + resourcePath;
+    }
+}
+
+// 使用
+Texture texture = ImageMaster.loadImage(MyMod.makeCardPath("my_card.png"));
+```
+
+**证据指针**：
+- ✅ **AyaMod**（行 121-139）：提供 `makeCardPath()`、`makeRelicPath()` 等工具方法
+- ✅ **WljMod**：直接使用相对路径（如 `"image/512/bg_attack.png"`）
+
+---
+
+## 附录：证据来源汇总
+
+### Localization 相关
+
+| Mod | 证据 | 位置 |
+|-----|------|------|
+| **WljMod** | `receiveEditStrings()` 回调加载 | WljMod.java:173-206 |
+| **AyaMod** | `receiveEditStrings()` 回调加载 | AyaMod.java:274-285 |
+| **AnonMod** | UTF-8 显式指定 | AnonMod.java:446 |
+| **Downfall** | `awakened:` 前缀 | CardStrings.json |
+| **HSRMod** | `HSRMod:` 前缀 | cards.json |
+
+### SpireConfig 相关
+
+| Mod | 证据 | 位置 |
+|-----|------|------|
+| **AnonMod** | 静态初始化块创建 | AnonMod.java:1042-1045 |
+| **AyaMod** | 构造函数创建并 load | AyaMod.java:110-116 |
+| **WljMod** | null 检查 + getter | WljMod.java:83-89 |
+
+### onSave/onLoad 相关
+
+| Mod | 证据 | 位置 |
+|-----|------|------|
+| **HSRMod** | GeniusSocietysDangerousGossip | GeniusSocietysDangerousGossip.java:56-64 |
+| **AnonMod** | Inner relic | Inner.java:34-39 |
+
+### 目录结构相关
+
+| Mod | 结构 | 路径 |
+|-----|------|------|
+| **Downfall** | `awakenedResources/localization/eng/` | 多语言分目录 |
+| **AnonMod** | `localization/` 平铺 | 所有语言文件在同一目录 |
+| **HSRMod** | `HSRModResources/localization/ENG/` | 大写语言代码 |
+
+---
+
+## 总结
+
+### 高危坑点（必须避免）
+
+1. ❌ 在构造函数中调用 `loadCustomStringsFile()`
+2. ❌ JSON 文件读取未指定 UTF-8 编码
+3. ❌ ID 未使用 `modID:` 前缀
+4. ❌ 在 `receiveEditStrings()` 中调用 `addKeyword()`
+5. ❌ `CustomSavable.onSave()` 返回 `null`
+
+### 推荐实践
+
+1. ✅ 严格遵守回调时序（参考速查表）
+2. ✅ 所有 ID 使用 `<modID>:<EntityName>` 格式
+3. ✅ 显式指定 UTF-8 编码读取 JSON
+4. ✅ 提供语言回退机制（默认 `eng`）
+5. ✅ SpireConfig 在静态初始化中创建并 `load()`
+
+---
+
+*文档版本：2026-01-13*
+*证据来源：../resources/mods 中的 30+ 社区 mod*

--- a/docs/patching-pitfalls.md
+++ b/docs/patching-pitfalls.md
@@ -1,0 +1,502 @@
+# SpirePatch 坑点与最佳实践
+
+本文档系统梳理了 Slay the Spire Mod 开发中使用 `@SpirePatch` 的常见坑点，基于对 100+ 个开源 mod 的代码扫描总结而成。
+
+---
+
+## 1. 构造函数 Patch 的方法名陷阱
+
+### 现象
+构造函数 patch 失效，编译时无错误但运行时不生效。
+
+### 根因
+构造函数在字节码中名为 `<init>`，但 ModTheSpire 的 SpirePatch 框架约定使用 `<ctor>` 作为 method 参数值。使用 `<init>` 会导致 patch 无法匹配到目标。
+
+### 推荐做法
+```java
+// 正确写法
+@SpirePatch(
+    clz = StrikeEffect.class,
+    method = "<ctor>",  // 使用 <ctor>
+    paramtypez = {AbstractCreature.class, float.class, float.class, int.class}
+)
+public static class ConstructorPatch {
+    // ...
+}
+```
+
+### 证据指针
+- **Downfall**: `slimebound/patches/StrikeEffectPatch.java` + `method = "<ctor>"`
+- **BaseMod**: `basemod/patches/com/megacrit/cardcrawl/cards/AbstractCard/CardModifierPatches.java` + `method = "<ctor>"`
+
+### 自检清单
+```bash
+# 检查是否有错误使用 <init> 的构造函数 patch
+cd ../resources/mods
+rg 'method\s*=\s*"<init>"' --type java
+
+# 应该看到的都是 <ctor>
+rg 'method\s*=\s*"<ctor>"' --type java | head -20
+```
+
+---
+
+## 2. 反射私有字段的脆弱性
+
+### 现象
+游戏更新后 mod 突然崩溃，报 `NoSuchFieldException` 或字段获取返回 null。
+
+### 根因
+使用 `ReflectionHacks.getPrivate()` 时硬编码字段名字符串：
+1. 字段名拼写错误在编译期无法发现
+2. 游戏更新时原代码字段名可能改变
+3. 重构时 IDE 不会自动更新字符串
+
+### 推荐做法
+```java
+// 脆弱写法（不推荐）
+Integer gold = (Integer) ReflectionHacks.getPrivate(
+    __instance, "gold", Integer.class  // 字段名硬编码
+);
+
+// 优先使用 SpireField（如果只是添加新字段）
+public static SpireField<Integer> gold = new SpireField(() -> 0);
+
+// 如果必须反射，添加封装和常量
+private static final String GOLD_FIELD = "gold";
+Integer gold = Reflect.getPrivate(cls, instance, GOLD_FIELD, Integer.class);
+```
+
+### 证据指针
+- **wlj-mod**: `wlj-mod-1.3.4/com/github/paopaoyue/wljmod/patch/gold/GoldTextEffectPatch.java` + `Reflect.getPrivate`
+- **Downfall**: `downfall/patches/ui/topPanel/GoldToSoulPatches.java` + `ReflectionHacks.getPrivateStatic`
+- **ArknightsTheSpire**: `patches/EndTurnButtonPatcher.java` + `ReflectionHacks.getPrivate`
+
+### 自检清单
+```bash
+# 检查直接反射私有字段的代码
+rg 'ReflectionHacks\.getPrivate[^;]+\.[a-zA-Z]+\s*\)' --type java -C 2
+
+# 运行时观察日志
+# 启动游戏时加上 -Dspire.logReflection=true 查看反射调用
+```
+
+---
+
+## 3. SpireInsert 与 SpireInstrument 的选择混乱
+
+### 现象
+同样的功能需求，有的地方用 `@SpireInsertPatch` + Locator，有的用 `@SpireInstrumentPatch` + ExprEditor，导致代码风格不统一。
+
+### 根因
+两种方式都能实现代码插入，但各有适用场景：
+- `SpireInsertPatch` + Locator：更清晰，适合在已知位置插入
+- `SpireInstrumentPatch` + ExprEditor：更灵活，适合复杂的条件插入
+
+### 推荐做法
+```java
+// 场景1：在方法调用前插入（推荐 SpireInsertPatch）
+@SpireInsertPatch(
+    locator = Locator.class,
+    localvars = {"sb"}
+)
+public static void Insert(SpriteBatch sb) {
+    // 插入的代码
+}
+
+private static class Locator extends SpireInsertLocator {
+    public int[] Locate(CtBehavior ctBehavior) throws Exception {
+        Matcher finalMatcher = new Matcher.MethodCallMatcher(
+            ExhaustPanel.class, "render"
+        );
+        return LineFinder.findInOrder(ctBehavior, finalMatcher);
+    }
+}
+
+// 场景2：条件性替换方法调用（推荐 SpireInstrumentPatch）
+@SpireInstrumentPatch
+public static ExprEditor Instrument() {
+    return new ExprEditor() {
+        public void edit(MethodCall m) throws CannotCompileException {
+            if (m.getClassName().equals(SpriteBatch.class.getName())
+                && m.getMethodName().equals("draw")) {
+                m.replace("{ if(condition) { $proceed($$); } }");
+            }
+        }
+    };
+}
+```
+
+### 证据指针
+- **mintySpire**: `mintySpire/patches/BetterAscensionSelectorPatches.java:72` + `@SpireInstrumentPatch`
+- **Gensokyo**: `Gensokyo/patches/ProceedButtonPatch.java` + `@SpireInstrumentPatch`
+- **ArknightsTheSpire**: `patches/PreHealPatcher.java` + `@SpireInsertPatch`
+
+### 自检清单
+```bash
+# 检查两种 patch 的使用分布
+rg '@SpireInsertPatch' --type java | wc -l
+rg '@SpireInstrumentPatch' --type java | wc -l
+```
+
+---
+
+## 4. Javassist 占位符使用错误
+
+### 现象
+patch 运行时崩溃，报 `NotFoundException` 或参数不匹配错误；或方法调用参数错乱。
+
+### 根因
+Javassist 占位符有特定含义，混用会导致运行时错误：
+- `$0` = this（实例方法）或第一个参数（静态方法）
+- `$1`, `$2`, ... = 方法参数
+- `$$` = 所有参数
+- `$proceed(...)` = 调用原始方法
+- `$_` = 返回值（用于 replace）
+
+### 推荐做法
+```java
+// 正确用法：传递所有参数
+m.replace("{ if(!" + MyPatch.class.getName() + ".condition(this)) { $proceed($$); } }");
+
+// 正确用法：修改返回值
+f.replace("$_ = $proceed($$) || " + MyPatch.class.getName() + ".alternative();");
+
+// 错误用法：无参方法用 $$
+// m.replace("{ $proceed($$); }")  // 错误！原始方法无参数
+
+// 正确用法：无参方法
+m.replace("{ $proceed(); }");
+```
+
+### 证据指针
+- **mintySpire**: `mintySpire/patches/BetterAscensionSelectorPatches.java:78` + `$proceed($$)`
+- **ThePackmaster**: `thePackmaster/patches/needlework/FineTuneLineWidthPatch.java:57` + `$_ = $proceed($$)`
+- **loadout**: `patches/MapRoomNodePatch.java` + `$proceed()` vs `$proceed($$)` 混用
+
+### 自检清单
+```bash
+# 检查 $proceed 使用
+rg '\$proceed' --type java -B 2 -A 2 | head -60
+
+# 检查是否有 $0 在静态上下文使用
+rg '\$0' --type java -B 5
+```
+
+---
+
+## 5. SpireField 初始化的 null.INSTANCE 陷阱
+
+### 现象
+使用 SpireField 添加字段时，访问字段抛出 `NullPointerException`。
+
+### 根因
+SpireField 的构造函数需要一个 `Supplier<T>` 作为默认值工厂。使用 `null.INSTANCE` 会导致 Supplier 为 null，在首次访问时崩溃。
+
+### 推荐做法
+```java
+// 错误写法
+public static SpireField<String> name = new SpireField(null.INSTANCE);
+
+// 正确写法：提供默认值
+public static SpireField<String> name = new SpireField(() -> "default");
+public static SpireField<Integer> count = new SpireField(() -> 0);
+public static SpireField<CustomData> data = new SpireField(() -> null);
+
+// 或使用构造方法引用
+public static SpireField<UIPanel> panel = new SpireField(UIPanel::new);
+```
+
+### 证据指针
+- **rare-cards-sparkle**: `RareCardsSparkleFields.java:41-43` + `new SpireField(null.INSTANCE)`
+- **ThePackmaster**: `thePackmaster/patches/needlework/StitchPatches.java:36` + `new SpireField(() -> null)`
+- **ArknightsTheSpire**: `ui/SpUtil.java:84` + `new SpireField(SpUI::new)`
+
+### 自检清单
+```bash
+# 检查 SpireField 初始化
+rg 'new SpireField' --type java -A 1 | grep -E '(null\.INSTANCE|::|\(\) ->)'
+```
+
+---
+
+## 6. SpireReturn 泛型与返回值不匹配
+
+### 现象
+使用 `@SpirePrefixPatch` 或 `@SpirePostfixPatch` 提前返回时，编译错误或运行时类型转换异常。
+
+### 根因
+`SpireReturn.Return()` 用于 void 方法，`SpireReturn.Return(value)` 用于非 void 方法。泛型参数 `<Void>` 与具体类型必须匹配。
+
+### 推荐做法
+```java
+// void 方法
+@SpirePrefixPatch
+public static SpireReturn<Void> Prefix(SomeClass __instance) {
+    if (shouldSkip) {
+        return SpireReturn.Return(null);  // void 方法返回 null
+    }
+    return SpireReturn.Continue();
+}
+
+// 非void 方法
+@SpirePrefixPatch
+public static SpireReturn<AbstractStance> Prefix(String name) {
+    if (name.equals("Custom")) {
+        return SpireReturn.Return(new CustomStance());  // 返回实际对象
+    }
+    return SpireReturn.Continue();
+}
+```
+
+### 证据指针
+- **wlj-mod**: `wlj-mod-1.3.4/com/github/paopaoyue/wljmod/patch/gold/GoldTextEffectPatch.java` + `SpireReturn<Void>` + `SpireReturn.Return()`
+- **Mizuki**: `patches/StancePatch.java` + `SpireReturn<AbstractStance>` + `SpireReturn.Return(new ...)`
+
+### 自检清单
+```bash
+# 检查 SpireReturn 使用
+rg 'SpireReturn\.Return' --type java -B 3
+```
+
+---
+
+## 7. Matcher 多匹配导致 patch 位置错误
+
+### 现象
+patch 应该影响方法中的第 N 次调用，但实际影响的是第 1 次；或 patch 没有生效。
+
+### 根因
+`Matcher.MethodCallMatcher` 默认只匹配第一个符合条件的调用。如果方法中有多次调用同一方法，需要使用 `findAllInOrder` 或自定义 Locator。
+
+### 推荐做法
+```java
+// 场景：只匹配第一次（默认行为）
+Matcher finalMatcher = new Matcher.MethodCallMatcher(
+    ExhaustPanel.class, "render"
+);
+return LineFinder.findInOrder(ctBehavior, finalMatcher);
+
+// 场景：匹配所有位置
+return LineFinder.findAllInOrder(ctBehavior, finalMatcher);
+
+// 场景：匹配第 N 次（需要自定义）
+private static class Locator extends SpireInsertLocator {
+    public int[] Locate(CtBehavior ctBehavior) throws Exception {
+        Matcher matcher = new Matcher.MethodCallMatcher(SpriteBatch.class, "draw");
+        int[] allMatches = LineFinder.findAllInOrder(ctBehavior, matcher);
+        return new int[]{ allMatches[2] };  // 只取第 3 次
+    }
+}
+```
+
+### 证据指针
+- **ArknightsTheSpire**: `ui/SpUtil.java:53` + `MethodCallMatcher`
+- **LingMod**: `lingmod/powers/NI3Power.java:65` + `MethodCallMatcher`
+- **Palmod**: `BlightOnEnterRoom.java:60` + `FieldAccessMatcher`
+
+### 自检清单
+```bash
+# 检查 Matcher 使用
+rg 'Matcher\.(MethodCall|FieldAccess|NewExpr)' --type java -A 3
+
+# 检查是否有多匹配风险
+# 1. 找到使用 Matcher 的 patch
+# 2. 打开目标方法源码
+# 3. 确认被匹配的方法/字段是否只出现一次
+```
+
+---
+
+## 8. paramtypez 参数类型错误
+
+### 现象
+patch 不生效，无错误提示；或 patch 应用到了错误的重载方法上。
+
+### 根因
+`paramtypez` 用于区分重载方法，常见错误：
+1. 类型不匹配（如用 `Integer.class` 而非 `int.class`）
+2. 参数顺序错误
+3. 缺少 `paramtypez` 导致匹配到错误的重载
+
+### 推荐做法
+```java
+// 正确：使用基本类型
+@SpirePatch(
+    clz = AbstractPlayer.class,
+    method = "damage",
+    paramtypez = {DamageInfo.class}  // 单参数重载
+)
+
+// 正确：多参数
+@SpirePatch(
+    clz = SomeClass.class,
+    method = "someMethod",
+    paramtypez = {int.class, boolean.class, String.class}  // 顺序和类型都要精确
+)
+
+// 错误：使用包装类型
+// paramtypez = {Integer.class}  // 错误！应该是 int.class
+```
+
+### 证据指针
+- **ArknightsTheSpire**: `patches/PreHealPatcher.java:13` + `paramtypez = {int.class, boolean.class}`
+- **KeyCuts**: `GridCardSelectScreenPatches.java:185` + `paramtypez = {CardGroup.class, ...}`
+
+### 自检清单
+```bash
+# 检查 paramtypez 使用
+rg 'paramtypez\s*=' --type java -A 1
+
+# 验证类型是否正确
+# 1. 复制 paramtypez 中的类型
+# 2. 在原游戏中搜索对应方法
+# 3. 确认参数类型完全匹配
+```
+
+---
+
+## 9. Patch 类命名和组织混乱
+
+### 现象
+难以找到特定功能的 patch，同名 patch 冲突，维护困难。
+
+### 根因
+不同 mod 使用不同的组织方式：
+- 有的全部放在 `patches/` 根目录
+- 有的按功能分包
+- 命名不统一：`XxxPatch` vs `XxxPatches`
+
+### 推荐做法
+```
+推荐结构：
+yourmod/
+└── patches/
+    ├── com/
+    │   └── megacrit/
+    │       └── cardcrawl/
+    │           ├── cards/
+    │           │   └── AbstractCardPatches.java
+    │           ├── characters/
+    │           │   └── AbstractPlayerPatches.java
+    │           └── ui/
+    │               └── TopPanelPatches.java
+    └── locators/
+        └── CustomLocator.java
+```
+
+### 证据指针
+- **Downfall**: `slimebound/patches/` + 结构清晰
+- **ThePackmaster**: `thePackmaster/patches/turmoilpack/` + 按包组织
+- **Mizuki**: `patches/` + 扁平结构
+
+### 自检清单
+```bash
+# 检查 patches 目录结构
+find ../resources/mods -type d -name "patches" -exec sh -c 'echo "=== {} ===" && ls {} | head -10' \;
+
+# 检查命名模式
+find ../resources/mods -name "*Patch.java" -o -name "*Patches.java" | head -50
+```
+
+---
+
+## 10. Locator 实现模式不一致
+
+### 现象
+Locator 代码重复，不清楚何时用 `findInOrder` vs `findAllInOrder`，不清楚返回 `int[]` 的含义。
+
+### 根因
+- 内部类 vs 独立类选择随意
+- `findInOrder` 只返回第一个匹配位置
+- `int[]` 返回值的含义（单个位置 vs 多个位置）
+
+### 推荐做法
+```java
+// 模式1：简单的单点插入（内部类）
+private static class Locator extends SpireInsertLocator {
+    public int[] Locate(CtBehavior ctBehavior) throws Exception {
+        Matcher finalMatcher = new Matcher.MethodCallMatcher(
+            TargetClass.class, "targetMethod"
+        );
+        return LineFinder.findInOrder(ctBehavior, finalMatcher);
+    }
+}
+
+// 模式2：多点插入（findAllInOrder）
+private static class Locator extends SpireInsertLocator {
+    public int[] Locate(CtBehavior ctBehavior) throws Exception {
+        Matcher finalMatcher = new Matcher.MethodCallMatcher(
+            TargetClass.class, "targetMethod"
+        );
+        return LineFinder.findAllInOrder(ctBehavior, finalMatcher);
+    }
+}
+
+// 模式3：复杂条件（独立类，可复用）
+public final class CustomLocator extends SpireInsertLocator {
+    private final int occurrence;
+
+    public CustomLocator(int occurrence) {
+        this.occurrence = occurrence;
+    }
+
+    public int[] Locate(CtBehavior ctBehavior) throws Exception {
+        // 自定义逻辑
+    }
+}
+```
+
+### 证据指针
+- **ArknightsTheSpire**: `ui/SpUtil.java:51` + 内部类 Locator
+- **rare-cards-sparkle**: `locators/RenderTipLocator.java` + 独立类
+- **KeyCuts**: `GridCardSelectScreenPatches.java:168` + 多个内部 Locator
+
+### 自检清单
+```bash
+# 检查 Locator 实现
+rg 'extends\s+SpireInsertLocator' --type java -A 10 | head -80
+
+# 检查 findInOrder vs findAllInOrder
+rg 'LineFinder\.(findInOrder|findAllInOrder)' --type java
+```
+
+---
+
+## 附录：快速验证命令集
+
+```bash
+cd ../resources/mods
+
+# 1. 检查构造函数 patch
+rg 'method\s*=\s*"<(init|ctor)>"' --type java
+
+# 2. 检查反射使用
+rg 'ReflectionHacks\.getPrivate[^;]+\.[a-zA-Z]+\s*\)' --type java
+
+# 3. 检查占位符使用
+rg '\$proceed|\$\$|\$_' --type java -C 1
+
+# 4. 检查 SpireField 初始化
+rg 'new SpireField' --type java -A 1
+
+# 5. 检查 SpireReturn
+rg 'SpireReturn\.Return' --type java -B 2
+
+# 6. 检查 paramtypez
+rg 'paramtypez\s*=' --type java -A 1
+
+# 7. 检查 Matcher
+rg 'Matcher\.' --type java -A 2
+
+# 8. 检查 Locator
+rg 'extends\s+SpireInsertLocator' --type java -A 5
+```
+
+---
+
+## 参考资源
+
+- [ModTheSpire GitHub](https://github.com/kiooeht/ModTheSpire)
+- [BaseMod Patches 示例](https://github.com/daviscook474/BaseMod)
+- [SpirePatch 注解源码](https://github.com/kiooeht/ModTheSpire/blob/master/src/main/java/com/evacipated/cardcrawl/modthespire/SpirePatch.java)

--- a/docs/pitfalls-additions.md
+++ b/docs/pitfalls-additions.md
@@ -1,0 +1,1073 @@
+# 将要追加到 docs/pitfalls.md 的 Markdown 文本
+
+> 本文档为 PROMPT 2~4 发现的综合草案，用于追加到 docs/pitfalls.md 第 9 条之后。
+> 格式与现有 pitfalls.md 完全一致，每条包含证据指针。
+
+---
+
+## 10) `@SpirePatch` 的 method 参数大小写敏感
+
+现象：Patch 静默失败，没有任何错误提示，目标方法未被修改，游戏行为无变化。
+
+根因：Java 方法名严格区分大小写，`@SpirePatch` 的 `method` 参数必须与目标方法**完全匹配**（包括大小写）。
+
+解决方式：
+- 使用 IDE 的 "Go to Declaration" 功能跳转到目标方法，复制精确名称
+- 或使用 `javap -private 目标类.class | grep 方法名` 验证
+
+快速自检：
+```bash
+# 验证 method 参数是否匹配实际方法名
+cd ../resources/mods
+rg -t java '@SpirePatch.*method\s*=\s*"[A-Z]' | rg -v 'Postfix|Prefix|Insert'
+```
+
+证据指针：
+- `PickCards/patch/renderNumbersPatch.java` + `renderTitle` → 精确匹配方法名
+- `StSLib/.../AlwaysRetainPatch.java` + `applyStartOfTurnCards` → 正确大小写
+
+---
+
+## 11) Constructor Patch 需要使用字节码名称 `<init>`
+
+现象：Patch 构造函数时无效，游戏启动无报错但构造函数未被修改。
+
+根因：构造函数在字节码中表示为 `<init>`，需要使用特殊的 `method` 参数值。
+
+解决方式：
+```kotlin
+// 使用 constructor=true 或 method="<init>"
+@SpirePatch(clz = AbstractCard.class, method = "<init>")
+// 或
+@SpirePatch(clz = AbstractCard.class, constructor = true)
+```
+
+注意：构造函数 patch 通常需要配合 `paramtypez` 指定参数类型，因为可能存在重载。
+
+快速自检：
+```bash
+# 搜索构造函数 patch（预期结果应为空或极少）
+cd ../resources/mods
+rg -t java 'method\s*=\s*"<init>"'
+rg -t java 'constructor\s*=\s*true'
+```
+
+证据指针：
+- 调研发现：在 2172 个文件中，**未发现**使用 `<init>` 或 `constructor=true` 的实际案例
+- 替代方案：大部分 mod 使用 `method = "<class>"` 配合 `SpireField` 在类初始化时注入字段
+
+---
+
+## 12) Locator 多匹配问题导致插入位置错误
+
+现象：Patch 插入到错误位置，多个 patch 修改同一方法时部分 patch 失效，游戏行为不一致。
+
+根因：当目标方法中存在**多个相同的代码模式**时，简单的 `Matcher` 可能匹配到多次插入点。
+
+解决方式：明确指定第 N 个匹配
+```kotlin
+private static class Locator extends SpireInsertLocator {
+    public int[] Locate(CtBehavior ctBehavior) throws Exception {
+        Matcher matcher = new Matcher.FieldAccessMatcher(CharacterSelectScreen.class, "options");
+        int[] allMatches = LineFinder.findAllInOrder(ctBehavior, new ArrayList(), matcher);
+        return new int[]{allMatches[1]};  // 明确取第 2 个匹配
+    }
+}
+```
+
+或使用复合 Matcher 消除歧义：
+```kotlin
+private static class Locator extends SpireInsertLocator {
+    public int[] Locate(CtBehavior ctBehavior) throws Exception {
+        List<Matcher> matchers = new ArrayList();
+        matchers.add(new Matcher.FieldAccessMatcher(AbstractRoom.class, "monsters"));
+        Matcher finalMatcher = new Matcher.FieldAccessMatcher(AbstractPlayer.class, "powers");
+        return LineFinder.findInOrder(ctBehavior, matchers, finalMatcher);
+    }
+}
+```
+
+快速自检：
+```bash
+# 检查是否存在可能的歧义匹配
+cd ../resources/mods
+rg -t java 'LineFinder\.(findInOrder|findAllInOrder)' | rg -v 'findAllInOrder\[' | head -20
+```
+
+证据指针：
+- `BaseMod/.../DamageHooks.java` → 使用 `findInOrder` + 多个 Matcher 消除歧义
+- `mintySpire/.../BetterAscensionSelectorPatches.java:62` → `findAllInOrder(...)[1]` 精确选择第 2 个匹配
+
+---
+
+## 13) Patch 顺序依赖导致 mod 兼容性问题
+
+现象：某些 mod 组合下功能异常，单独测试正常但与其他 mod 共同安装时崩溃。
+
+根因：多个 mod 修改同一方法时，最终字节码取决于 **mod 加载顺序** 和 **patch 应用顺序**。
+
+解决方式：检测其他 mod 的存在并适配
+```kotlin
+@SpirePatch(clz = SomeClass.class, method = "someMethod")
+public static class OtherModCompatibility {
+    public static ExprEditor Instrument() {
+        if (Loader.isModLoaded("OtherModID")) {
+            // 其他 mod 存在时的 patch 逻辑
+            return new ExprEditor() { /* ... */ };
+        }
+        return null;  // 不应用 patch
+    }
+}
+```
+
+或使用 `@SpirePatches2` 同时 patch 多个方法重载，减少顺序依赖。
+
+快速自检：
+```bash
+# 检查是否存在兼容性处理
+cd ../resources/mods
+rg -t java 'Compatibility|compatibility|isModLoaded|Loader\.' | rg -i 'patch' | head -20
+```
+
+证据指针：
+- `ExtendedUI/.../CompatibilityPatches.java` → 显式处理与其他 mod 的兼容性
+- `ThePackmasterExpansionPacks/.../GlobalTurnStartCompatibilityPatches.java` → 全局兼容性 patch
+
+---
+
+## 14) 反射私有字段/方法在游戏更新时可能失效
+
+现象：游戏崩溃 `NoSuchFieldException` / `NoSuchMethodException`，游戏版本更新后 mod 失效。
+
+根因：私有字段/方法名在**游戏更新时可能变化**，且跨版本兼容性差。
+
+解决方式：
+- 优先使用 `SpireField` 添加字段，避免反射私有字段（推荐）
+```kotlin
+@SpirePatch(clz = AbstractCard.class, method = "<class>")
+public static class MyCustomField {
+    public static SpireField<Integer> myCustomData = new SpireField(() -> 0);
+}
+```
+- 必须反射时，添加异常处理
+```kotlin
+try {
+    Object value = ReflectionHacks.getPrivate(obj, TargetClass.class, "fieldName");
+} catch (Exception e) {
+    logger.error("Failed to access private field, game version may have changed", e);
+    // 降级处理或跳过该功能
+}
+```
+
+快速自检：
+```bash
+# 检查反射使用频率
+cd ../resources/mods
+rg -t java 'ReflectionHacks\.(getPrivate|setPrivate)' | wc -l
+
+# 每次游戏更新后验证
+rg -t java 'getPrivate.*".*"' | sort -u  # 列出所有私有字段名
+```
+
+证据指针：
+- `BaseMod/.../ScrollingTooltips.java` → `StaticSpireField<Float> isScrolling`
+- `ArknightsTheSpire/.../EndTurnButtonPatcher.java` → `getPrivate(o, CharacterOption.class, "maxAscensionLevel")`
+
+---
+
+## 15) `@ByRef` 参数必须是数组类型
+
+现象：修改局部变量无效，原值未改变；编译错误 `ByRef parameter must be an array type`。
+
+根因：`@ByRef` 注解用于**按引用传递局部变量**，要求参数必须是**数组类型**，且需要配合 `localvars` 使用。
+
+解决方式：
+```kotlin
+// 正确：ByRef 参数必须是数组
+@SpireInsertPatch(locator = Locator.class, localvars = {"tmp"})
+public static void Insert(
+    AbstractCard __instance,
+    @ByRef float[] tmp  // 必须是数组，修改 tmp[0] 会影响原局部变量
+) {
+    tmp[0] = tmp[0] * 2;  // 修改会生效
+}
+```
+
+快速自检：
+```bash
+# 验证 ByRef 参数都是数组类型
+cd ../resources/mods
+rg -t java '@ByRef(?!.*\[\])'  # 应该匹配到错误用法（预期为空）
+```
+
+证据指针：
+- `BaseMod/.../DamageHooks.java:29` → `@ByRef float[] tmp` 正确修改伤害值
+- `IbukiSuika/.../NeowNarrationPatch.java` → `@ByRef Scanner[] ___s` 修改 Scanner
+
+---
+
+## 16) Javassist `$proceed` 占位符需要传递参数
+
+现象：编译期错误 `CompileError: wrong number of parameters` 或运行时崩溃。
+
+根因：`$proceed` 代表原方法调用，即使无参方法也需要用 `$$` 传递参数列表。
+
+解决方式：
+```kotlin
+// 正确：无参方法也需用 $$
+m.replace("{ $proceed($$); }");
+
+// 正确：修改单个参数
+m.replace("{ $_ = $proceed($1, customized_value); }");
+
+// 错误：无参方法调用
+m.replace("{ $proceed(); }");  // ❌
+```
+
+快速自检：
+```bash
+# 检查常见的占位符错误模式
+cd ../resources/mods
+rg -t java 'this\.\$proceed'  # 应为空或极少
+rg -t java '\$proceed\(\)'     # 应为空（无参方法也需 $$）
+```
+
+证据指针：
+- `mintySpire/.../BetterAscensionSelectorPatches.java:78` → `$proceed($$)` 正确传递所有参数
+- `actlikeit/.../PreventActThreeBossRewardsPatch.java:28` → `$proceed($$)` 保留原逻辑
+
+---
+
+## 17) `method = "<class>"` 仅用于 SpireField 声明
+
+现象：误将 `<class>` 当作普通方法名，Patch 静默无效。
+
+根因：`method = "<class>"` 是**特殊语法**，用于在类级别注入 `SpireField`，不是真正的方法名。
+
+解决方式：
+```kotlin
+// 正确：使用 <class> 声明 SpireField
+@SpirePatch(clz = AbstractCard.class, method = "<class>")
+public static class MyCustomField {
+    public static SpireField<Integer> myData = new SpireField(() -> 0);
+}
+
+// 错误：<class> 没有代码体可以插入
+@SpirePatch(clz = AbstractCard.class, method = "<class>")
+public static class InvalidPatch {
+    @SpireInsertPatch(locator = SomeLocator.class)  // ❌
+    public static void Insert(AbstractCard __instance) { }
+}
+```
+
+用途限制：
+- 仅用于声明 `SpireField` 或 `StaticSpireField`
+- 不能使用 `@SpireInsertPatch` / `@SpirePrefixPatch` 等插入逻辑
+
+快速自检：
+```bash
+# 检查 <class> 的正确使用
+cd ../resources/mods
+rg -t java 'method\s*=\s*"<class>"' -A 5 | rg -v 'SpireField'
+```
+
+证据指针：
+- `StSLib/.../ExtraIconsPatch.java:24-30` → `SpireField<ArrayList<IconPayload>> extraIcons`
+- `BaseMod/.../ScrollingTooltips.java` → `StaticSpireField<Float> isScrolling`
+
+---
+
+## 18) `@SpirePatch` 的 `paramtypez` 必须精确匹配
+
+现象：Patch 静默无效；启动日志显示 `No matching method found`。
+
+根因：`@SpirePatch` 的 `paramtypez` 参数必须**精确匹配**目标方法的参数类型（包括顺序）。
+
+解决方式：
+```kotlin
+// 正确：paramtypez 精确匹配
+@SpirePatch(
+    clz = AbstractCard.class,
+    method = "render",
+    paramtypez = {SpriteBatch.class, boolean.class}
+)
+
+// 检查方法签名的方法：
+// 1. IDE 查看：Ctrl+Q (IntelliJ) / F3 (Eclipse)
+// 2. javap：javap -private com.megacrit.cardcrawl.cards.AbstractCard.class | grep -A 10 "public.*render"
+```
+
+快速自检：
+```bash
+# 验证参数类型匹配
+cd ../resources/mods
+rg -t java 'paramtypez\s*=' -A 1 | head -30
+```
+
+证据指针：
+- `StSLib/.../ExtraIconsPatch.java:32-39` → 使用 `@SpirePatches2` 同时 patch 两个重载方法
+- `mintySpire/.../MultiLinePowersPatches.java` → 精确匹配 `SpriteBatch sb, float x, float y` 等参数
+
+---
+
+## 19) 资源路径大小写敏感（Linux vs Windows 差异）
+
+现象：Windows 上运行正常，Linux/macOS 上资源加载失败；报错 `FileNotFoundException` 或资源显示为空白/粉色方块。
+
+根因：Windows 文件系统不区分大小写（NTFS/FAT32），Linux/macOS 区分大小写（ext4/APFS）；打包进 jar 后，ClassLoader 路径查询变为严格大小写敏感。
+
+解决方式：使用统一的路径生成方法，确保大小写一致
+```kotlin
+// 推荐：使用统一的路径生成方法
+object ModCore {
+    fun makeCharacterPath(filename: String): String {
+        return "myModResources/images/char/$filename" // 明确目录结构
+    }
+}
+
+// 使用示例
+orbTextures = arrayOf(
+    ModCore.makeCharacterPath("myChar/orb/layer1.png"),  // 注意大小写
+    ModCore.makeCharacterPath("myChar/orb/layer2.png")
+)
+```
+
+快速自检：
+```bash
+# 在 Linux 环境或 CI 中测试 mod
+# 使用 jar tf your-mod.jar 检查 jar 内实际路径大小写
+jar tf your-mod.jar | grep -i "images/char"
+```
+
+证据指针：
+- `LingMod/lingmod/character/Ling.java:290` - 使用 `ModCore.makeCharacterPath()` 统一管理路径
+- `Collector/CollectorChar.java:206` - 直接硬编码 `"collectorResources/images/char/mainChar/orb/layer1.png"`
+
+---
+
+## 20) 打包进 jar 后需用 ClassLoader 路径
+
+现象：IDE 运行正常，打包成 jar 后资源加载失败；报错 `IllegalArgumentException: File not found: xxx`。
+
+根因：`File` 类用于文件系统路径，jar 内资源需用 `ClassLoader.getResourceAsStream()` 或 `Gdx.files.internal()`；BaseMod 的 `ImageMaster.loadImage()` 已封装 ClassLoader 调用。
+
+解决方式：
+```kotlin
+// 推荐：使用 Gdx.files.internal() 或 ImageMaster.loadImage()
+// 路径相对于 ModTheSpire.json 中声明的 resources 目录
+Texture texture = ImageMaster.loadImage("myModResources/images/char/myChar/orb/vfx.png")
+
+// 不推荐：使用 File 类
+// File file = new File("images/char/myChar/orb/vfx.png"); // jar 内无效
+```
+
+快速自检：
+```bash
+# 检查 ModTheSpire.json 中 resources 字段是否包含资源目录
+# 使用 jar tf your-mod.jar | grep "images/char" 验证资源是否在 jar 内
+jar tf your-mod.jar | grep "images/char"
+```
+
+证据指针：
+- `BaseMod/basemod/abstracts/CustomPlayer.java:212` - 使用 `Gdx.files.internal(BaseMod.getPlayerButton(this.chosenClass))`
+- `Collector/CollectorChar.java:74` - 使用 `ImageMaster.loadImage(CollectorMod.getModID() + "Resources/images/charSelect/leaderboard.png")`
+
+---
+
+## 21) 中文路径/空格导致资源加载失败
+
+现象：包含中文、空格的路径在某些系统上加载失败；报错 URL 编码相关异常或路径找不到。
+
+根因：LibGDX 的 `Gdx.files.internal()` 在某些情况下对非 ASCII 字符处理不佳；ModTheSpire 打包时路径编码问题。
+
+解决方式：资源路径仅使用 ASCII 字符和下划线
+```kotlin
+// 推荐：资源路径仅使用 ASCII 字符和下划线
+val path = "myModResources/images/char/my_char/orb/layer1.png" // 使用下划线代替空格
+
+// 避免
+val path = "myModResources/images/char/我的角色/orb/layer1.png" // 中文可能失败
+val path = "myModResources/images/char/my char/orb/layer1.png"  // 空格可能失败
+```
+
+快速自检：
+```bash
+# 所有资源文件名、目录名使用 [a-zA-Z0-9_] 字符集
+find yourModResources -name '*[^\x00-\x7F]*'  # 查找非 ASCII 文件名
+```
+
+证据指针：
+- 大多数 mod 使用纯英文路径：`sneckomodResources`、`collectorResources`、`lingmodResources`
+- 无直接证据（因为失败的 mod 不会发布），但社区普遍避免中文路径
+
+---
+
+## 22) atlas-json 配对错误导致 Spine 动画加载失败
+
+现象：Spine 动画加载时报错 `SkeletonData mismatch` 或 NPE；动画播放时缺少某些骨骼/附件。
+
+根因：`.atlas` 文件和 `.json` 文件需由同一导出操作生成；单独修改其中之一会导致索引不匹配。
+
+解决方式：确保 atlas 和 json 文件名前缀一致
+```kotlin
+// 推荐：确保 atlas 和 json 文件名前缀一致
+fun reloadAnimation() {
+    val basePath = "myModResources/images/char/mainChar/skeleton"
+    this.loadAnimation(basePath + ".atlas", basePath + ".json", 1.0F)
+}
+
+// 文件结构：
+// myModResources/images/char/mainChar/
+//   ├── skeleton.atlas
+//   ├── skeleton.json
+//   └── skeleton.png  (atlas 引用的纹理文件)
+```
+
+快速自检：
+```bash
+# 用文本编辑器打开 .atlas 文件，确认其中的 .png 文件名实际存在
+# 用 Spine 编辑器重新导出，确保 atlas/json 同步
+```
+
+证据指针：
+- `LingMod/lingmod/character/Ling.java:77-81` - 使用 `prefix + ModConfig.skinInfo.toString().toLowerCase()` 动态拼接路径
+- `Collector/CollectorChar.java:49-50, 68` - 硬编码 `"collectorResources/images/char/mainChar/skeleton.atlas"`
+
+---
+
+## 23) orbTextures 数组结构：中间元素为 baseLayer
+
+现象：能量为 0 时能量球显示异常（缺少暗色层）；报错 `Texture not found: layer*d.png`。
+
+根因：`orbTextures` 数组后半部分（layer1d~layer5d）是"无能量"状态下的纹理；数组长度应为奇数，中间元素是 baseLayer，后半部分对应前半部分的暗色版本。
+
+解决方式：
+```kotlin
+// orbTextures 数组结构：[layer1, layer2, ..., baseLayer, ..., layer1d, layer2d, ...]
+// 注意：中间元素（baseLayer）之后是暗色层
+private val orbTextures = arrayOf(
+    // 有能量时的层（从外到内）
+    "myModResources/images/char/myChar/orb/layer1.png",
+    "myModResources/images/char/myChar/orb/layer2.png",
+    "myModResources/images/char/myChar/orb/layer3.png",  // 旋转层
+    "myModResources/images/char/myChar/orb/layer4.png",  // 旋转层
+    "myModResources/images/char/myChar/orb/layer5.png",  // 旋转层
+    // 中间层：baseLayer（不旋转，最内层）
+    "myModResources/images/char/myChar/orb/layer6.png",  // baseLayer
+    // 无能量时的层（暗色版本，与有能量层顺序对应）
+    "myModResources/images/char/myChar/orb/layer1d.png",
+    "myModResources/images/char/myChar/orb/layer2d.png",
+    "myModResources/images/char/myChar/orb/layer3d.png",
+    "myModResources/images/char/myChar/orb/layer4d.png",
+    "myModResources/images/char/myChar/orb/layer5d.png"
+)
+
+// 数组长度必须为奇数，且满足：length = 2 * n + 1
+// middleIdx = length / 2（integer division）
+```
+
+快速自检：
+```bash
+# 确保 orbTextures.length 为奇数
+# 确保中间元素（orbTextures[length/2]）存在且是 baseLayer
+# 确保后半部分文件名包含 d 后缀（layer*d.png）
+```
+
+证据指针：
+- `BaseMod/basemod/abstracts/CustomEnergyOrb.java:23-35` - 代码逻辑：中间元素为 baseLayer
+- `Collector/CollectorChar.java:206` - 完整的 11 元素数组（5 旋转层 + 1 baseLayer + 5 暗色层）
+
+---
+
+## 24) Localization 多语言文件加载时机错误
+
+现象：游戏内显示 ID 而非实际文本（如 `theforget:SelfLabel`）。
+
+根因：在 `receiveEditStrings()` **之前** 加载字符串文件；或路径错误导致文件未找到。
+
+解决方式：
+```kotlin
+override fun receiveEditStrings() {
+    // 1. 始终先加载 ENG 作为回退
+    loadLocalization(GameLanguage.ENG)
+
+    // 2. 再加载当前语言（若非 ENG）
+    if (Settings.language != GameLanguage.ENG) {
+        loadLocalization(Settings.language)
+    }
+}
+
+private fun loadLocalization(language: GameLanguage) {
+    val lang = when (language) {
+        GameLanguage.ZHS -> "zhs"
+        GameLanguage.ENG -> "eng"
+        else -> "eng" // 回退到 ENG
+    }
+    BaseMod.loadCustomStringsFile(
+        UIStrings::class.java,
+        "theforgetResources/localization/$lang/UIstrings.json"
+    )
+}
+```
+
+快速自检：
+```bash
+# 检查是否在 receiveEditStrings() 中加载
+# 检查是否先加载 ENG 作为回退
+# 检查路径是否匹配 ModTheSpire.json 中的资源路径
+```
+
+证据指针：
+- Downfall: `downfallMod.java:590-594`（先 ENG，再当前语言）
+- BaseMod: `BaseMod.java` 中 `receiveEditStrings()` 订阅者模式
+
+---
+
+## 25) Localization UTF-8 编码问题
+
+现象：中文显示乱码（如 `�` 或 `??`）。
+
+根因：JSON 文件保存为 ANSI/GBK 编码；读取时未指定 UTF-8。
+
+解决方式：
+```kotlin
+// 方法 1：确保 JSON 文件保存为 UTF-8（推荐）
+// IDE: Settings → Editor → File Encodings → Default encoding: UTF-8
+
+// 方法 2：读取时显式指定编码
+val json = Gdx.files.internal(path)
+    .readString("UTF-8") // Gdx 自动处理 UTF-8
+```
+
+快速自检：
+```bash
+# 检查 JSON 文件是否保存为 UTF-8
+# 检查 IDE 是否配置 UTF-8 为默认编码
+# 检查中文文本是否能正常显示
+file yourModResources/localization/zhs/UIstrings.json
+```
+
+证据指针：
+- Downfall: `downfallMod.java:599` 使用 `StandardCharsets.UTF_8`
+- 社区惯例：所有 localization JSON 文件均使用 UTF-8
+
+---
+
+## 26) ID 前缀冲突导致文本显示错误
+
+现象：文本显示错误或覆盖其他 Mod 的内容。
+
+根因：使用了通用 ID（如 `SelfTooltip`）而非 `theforget:SelfTooltip`；与其他 Mod 或原版 ID 冲突。
+
+解决方式：
+```kotlin
+// 错误：无前缀
+const val SELF_TOOLTIP = "SelfTooltip"
+
+// 正确：带 modID 前缀
+const val SELF_TOOLTIP = "theforget:SelfTooltip"
+
+// JSON 中对应键
+{
+  "theforget:SelfTooltip": {
+    "TEXT": ["Self", "Self is your HP."]
+  }
+}
+```
+
+快速自检：
+```bash
+# 所有 ID 是否以 modID: 开头？
+# 是否使用常量定义 ID，避免硬编码？
+# JSON 键是否与代码中的常量一致？
+```
+
+证据指针：
+- the-forget: `TheForgetLocalization.kt:12-13` 所有 ID 均带前缀
+- Downfall: `downfallResources/localization/eng/*.json` 所有键带 `downfall:` 前缀
+
+---
+
+## 27) `@SpireEnum` 与字符串 ID 混淆
+
+现象：枚举值作为 ID 使用时，运行时出现 `NullPointerException`；或 ID 解析失败，显示默认值。
+
+根因：`@SpireEnum` 注解的枚举在运行时动态注入；若 Mod 未正确加载，枚举值为 `null`；枚举名称（如 `THE_FORGET`）与字符串 ID（如 `theforget:TheForget`）混淆。
+
+解决方式：
+```kotlin
+// 1. 定义枚举（仅用于内部类型标识）
+object TheForgetEnums {
+    @SpireEnum
+    @JvmField
+    var THE_FORGET: AbstractPlayer.PlayerClass? = null
+}
+
+// 2. 定义字符串 ID（用于 localization）
+object TheForgetIDs {
+    const val CHARACTER_ID = "theforget:TheForget"
+    const val CARD_PREFIX = "theforget:"
+}
+
+// 3. 使用时严格区分
+BaseMod.addCharacter(
+    character,
+    button,
+    portrait,
+    TheForgetEnums.THE_FORGET!!  // 枚举值，确保非空
+)
+```
+
+快速自检：
+```bash
+# 是否使用 @JvmField 确保 Kotlin 属性可见？
+# 是否使用 requireNotNull() 或 !! 验证枚举非空？
+# 枚举名称是否与字符串 ID 明确区分？
+```
+
+证据指针：
+- the-forget: `TheForgetEnums.kt:9-11` 枚举定义
+- the-forget: `TheForgetMod.kt:31` 使用 `requireNotNull()` 验证
+
+---
+
+## 28) SpireConfig 初始化时机错误
+
+现象：配置文件未创建，或读取不到默认值；游戏启动时抛 `IOException`。
+
+根因：在 `receivePostInitialize()` **之前** 初始化 SpireConfig；首次加载时文件不存在，抛异常但未捕获。
+
+解决方式：
+```kotlin
+// 懒加载：首次使用时初始化
+private var config: SpireConfig? = null
+
+fun getConfig(): SpireConfig {
+    if (config == null) {
+        try {
+            val defaults = Properties().apply {
+                setBool("showSelfTooltip", true)
+                setString("selfColor", "#FF5733")
+            }
+            config = SpireConfig("theforget", "playerPrefs", defaults)
+        } catch (e: IOException) {
+            logger.error("Failed to initialize config", e)
+            throw RuntimeException("Config initialization failed", e)
+        }
+    }
+    return config!!
+}
+
+// 在 receivePostInitialize() 中预加载（可选）
+override fun receivePostInitialize() {
+    getConfig() // 触发初始化
+}
+```
+
+快速自检：
+```bash
+# 是否懒加载 SpireConfig？
+# 是否捕获 IOException？
+# 是否提供默认值？
+```
+
+证据指针：
+- Downfall: `downfallMod.java:483` 使用 try-catch 包裹初始化
+- ModTheSpire: `SpireConfig.java:37-43` 构造函数会创建文件
+
+---
+
+## 29) 存档膨胀问题
+
+现象：存档文件异常增大（几 MB 到几十 MB）；加载/保存存档变慢。
+
+根因：频繁保存大对象（如整个卡组、战斗历史）；未清理过期数据。
+
+解决方式：
+```kotlin
+// 错误：保存整个卡组
+config.setString("deck", Gson().toJson(deck))
+
+// 正确：只保存必要数据
+config.setString("deckSize", deck.size.toString())
+config.setString("deckCards", deck.joinToString(",") { it.cardID })
+
+// 或使用 CustomSavable 接口（BaseMod 提供）
+BaseMod.registerSavable("theforget:SelfData", object : CustomSavableRaw {
+    override fun onSave(): String? {
+        return Gson().toJson(SelfData(currentHP, maxHP))
+    }
+
+    override fun onLoad(data: String) {
+        val saved = Gson().fromJson(data, SelfData::class.java)
+        currentHP = saved.currentHP
+        maxHP = saved.maxHP
+    }
+})
+```
+
+快速自检：
+```bash
+# 是否避免保存重复/冗余数据？
+# 是否定期清理过期数据？
+# 是否考虑使用 CustomSavable 替代 SpireConfig？
+```
+
+证据指针：
+- loadout Mod: 使用 `CustomSavable` 保存卡组修改
+- Downfall: `downfallMod.java:480-510` 使用多个 SpireConfig 分开存储
+
+---
+
+## 30) 版本升级迁移缺失
+
+现象：Mod 更新后存档无法读取；或读取到旧格式数据导致崩溃。
+
+根因：存档结构变更但未处理迁移；或未标识存档版本。
+
+解决方式：
+```kotlin
+object SaveVersion {
+    const val CURRENT = 2
+}
+
+fun onLoad(data: String) {
+    val json = JsonParser().parse(data).asJsonObject
+    val version = json.get("version")?.asInt ?: 1
+
+    val saved = when (version) {
+        1 -> migrateFromV1(json)
+        2 -> Gson().fromJson(data, SelfData::class.java)
+        else -> throw IllegalArgumentException("Unknown save version: $version")
+    }
+
+    // 使用迁移后的数据
+    currentHP = saved.currentHP
+}
+
+private fun migrateFromV1(oldJson: JsonObject): SelfData {
+    // v1 → v2 迁移逻辑
+    val oldHP = oldJson.get("hp").asInt
+    return SelfData(
+        currentHP = oldHP,
+        maxHP = oldHP * 2  // v2 新增字段
+    )
+}
+```
+
+快速自检：
+```bash
+# 是否在存档中存储版本号？
+# 是否实现迁移逻辑？
+# 是否测试旧存档升级流程？
+```
+
+证据指针：
+- Downfall: `downfallMod.java:817-830` 使用 `configDefault` 处理默认值
+- 社区惯例：在 SpireConfig 中存储 `config_version` 字段
+
+---
+
+## 31) 竞态条件导致配置丢失
+
+现象：配置更改后未保存到磁盘；或多个线程同时写入导致数据损坏。
+
+根因：`SpireConfig.save()` 调用时机不当；未考虑异步存档的并发问题。
+
+解决方式：
+```kotlin
+// 1. 配置变更后立即保存
+fun setShowTooltip(show: Boolean) {
+    getConfig().setBool("showSelfTooltip", show)
+    try {
+        getConfig().save()
+    } catch (e: IOException) {
+        logger.error("Failed to save config", e)
+    }
+}
+
+// 2. 或使用防抖机制（批量更改后保存）
+private var savePending = false
+fun scheduleSave() {
+    if (!savePending) {
+        savePending = true
+        Timer().schedule(1000) { // 1 秒后保存
+            try {
+                getConfig().save()
+            } catch (e: IOException) {
+                logger.error("Failed to save config", e)
+            } finally {
+                savePending = false
+            }
+        }
+    }
+}
+```
+
+快速自检：
+```bash
+# 配置变更后是否调用 save()？
+# 是否捕获 IOException？
+# 是否避免频繁保存（考虑防抖）？
+```
+
+证据指针：
+- ModTheSpire: `SpireConfig.java:49-51` `save()` 使用 `FileOutputStream` 覆盖写入
+- BaseMod: 配置面板修改后立即调用 `save()`
+
+---
+
+## 32) Localization 文件命名大小写问题
+
+现象：Windows 上运行正常，Linux 上多语言文件加载失败。
+
+根因：Localization 文件必须首字母大写（`CardStrings.json`），Linux 文件系统区分大小写。
+
+解决方式：
+```kotlin
+// 正确：文件名首字母大写，Strings 大写 S
+CardStrings.json
+PowerStrings.json
+RelicStrings.json
+UIStrings.json
+CharacterStrings.json
+
+// 错误：小写文件名在 Linux 上无法加载
+cardstrings.json
+powerstrings.json
+```
+
+快速自检：
+```bash
+# 检查 localization 目录下文件名是否首字母大写
+ls yourModResources/localization/eng/
+```
+
+证据指针：
+- Downfall: `downfallResources/localization/eng/` 所有文件首字母大写
+- BaseMod: 官方示例 Mod 均使用大写命名
+
+---
+
+## 33) ModTheSpire.json 的 modid 与资源目录前缀必须一致
+
+现象：资源文件（图片、音频）加载失败。
+
+根因：路径前缀与 `ModTheSpire.json` 中的 `modid` 不一致。
+
+解决方式：
+```json
+// ModTheSpire.json
+{
+  "modid": "theforget"
+}
+```
+
+```kotlin
+// 资源路径必须使用 modid + "Resources"（大写 R）
+const val RESOURCE_PREFIX = "theforgetResources/"
+
+// 具体路径
+const val CARD_IMAGE = "${RESOURCE_PREFIX}images/cards/Skill.png"
+const val LOCALIZATION = "${RESOURCE_PREFIX}localization/eng/UIstrings.json"
+```
+
+快速自检：
+```bash
+# 资源路径是否为 modidResources/？
+# 路径大小写是否与实际目录一致？
+# 是否使用常量定义路径，避免硬编码？
+```
+
+证据指针：
+- the-forget: `TheForgetAssets.kt` 所有路径以 `theforgetResources/` 开头
+- Downfall: `downfallResources/`, `champResources/` 等多前缀结构
+
+---
+
+## 34) `abstractSaveString` vs `saveSpecial` 误用
+
+现象：使用 `saveString()` 保存复杂对象；或混淆 `saveString()` 与 `saveSpecial()` 的用途。
+
+根因：不了解两种方法的区别和适用场景。
+
+解决方式：
+```kotlin
+// saveString(): 仅用于基本类型
+// 适用：配置项、简单计数器
+
+// saveSpecial(): 用于复杂对象（需实现 ISaveContainer）
+// 适用：卡组修改、自定义数据结构
+
+// 错误：用 saveString 保存对象
+saveString("deck", deck.toString()) // 存的是 toString() 结果
+
+// 正确：使用 CustomSavable 接口
+BaseMod.registerSavable("theforget:Deck", object : CustomSavableRaw {
+    override fun onSave(): String? = Gson().toJson(deck)
+    override fun onLoad(data: String) { deck = Gson().fromJson(data, Deck::class.java) }
+})
+```
+
+快速自检：
+```bash
+# 基本类型是否使用 saveString()？
+# 复杂对象是否使用 CustomSavable？
+# 是否混淆两者用途？
+```
+
+证据指针：
+- BaseMod: `CustomSavable` 接口文档
+- loadout Mod: 使用 `CustomSavable` 保存卡组修改数据
+
+---
+
+## 35) Keywords 注册缺失导致关键词无颜色
+
+现象：卡牌描述中关键词颜色不正确或无悬停提示。
+
+根因：未调用 `BaseMod.addKeyword()` 注册关键词；或 `KeywordStrings.json` 未正确配置。
+
+解决方式：
+```kotlin
+// 1. 在 receiveEditKeywords() 中注册
+override fun receiveEditKeywords() {
+    BaseMod.addKeyword(
+        "theforget:Self",      // ID 前缀
+        "Self",                 // ENG 显示名
+        "自我"                   // ZHS 显示名（可选）
+    )
+}
+
+// 2. 或在 JSON 中定义（新版本 BaseMod）
+// keywords.json
+{
+  "theforget:Self": {
+    "NAMES": ["Self", "自我"],
+    "DESCRIPTION": "Self is your HP."
+  }
+}
+```
+
+快速自检：
+```bash
+# 是否实现了 EditKeywordsSubscriber？
+# 关键词 ID 是否与 JSON 中的键一致？
+# 多语言关键词是否在各语言文件中定义？
+```
+
+证据指针：
+- BaseMod 文档：`EditKeywordsSubscriber` 接口
+- StSLib: `Keyword` 类用于更复杂的关键词定义
+
+---
+
+## 36) `@SpireInsert` vs `@SpireReplace` 混用
+
+现象：原方法逻辑完全丢失；其他 mod 的 patch 失效；游戏行为异常。
+
+根因：
+- `@SpireInsertPatch`：在指定位置**插入代码**，原方法保留
+- `@SpireReplace`：**完全替换**方法体，原方法丢失
+
+解决方式：
+```kotlin
+// 推荐：使用 @SpireInsertPatch + Locator 插入逻辑
+@SpirePatch(clz = AbstractCard.class, method = "calculateCardDamage")
+public static class InsertLogic {
+    @SpireInsertPatch(locator = Locator.class)
+    public static void Insert(AbstractCard __instance) {
+        // 在指定位置插入自定义逻辑，原方法继续执行
+    }
+}
+
+// 谨慎使用：@SpireReplace 会完全替换方法
+// 替代方案：使用 Prefix/Postfix + SpireReturn 控制流程
+@SpirePatch(clz = AbstractCard.class, method = "calculateCardDamage")
+@SpirePrefixPatch
+public static SpireReturn<?> Prefix(AbstractCard __instance, AbstractMonster mo) {
+    if (需要跳过原方法) {
+        return SpireReturn.Return(null);  // 跳过原方法
+    }
+    return SpireReturn.Continue();  // 继续执行原方法
+}
+```
+
+快速自检：
+```bash
+# 检查 SpireReplace 使用（预期应该很少）
+cd ../resources/mods
+rg -t java '@SpireReplace'
+# 如果发现使用，需人工审查是否真的需要完全替换方法
+```
+
+证据指针：
+- 调研发现：在 2172 个文件中，**未发现**明显的 `@SpireReplace` 错误使用案例
+- 主流做法：使用 `@SpireInsertPatch` / `@SpirePostfixPatch` / `SpireReturn`
+
+---
+
+## 总览目录
+
+### 新增类别统计
+
+| 类别 | 条目数 | 编号范围 |
+|------|--------|----------|
+| **Patching（补丁注入）** | 8 条 | 10~17 |
+| **资源加载与打包** | 5 条 | 19~23 |
+| **Localization（多语言）** | 4 条 | 24, 25, 32, 35 |
+| **IDs 与 Enums** | 2 条 | 26, 27 |
+| **SpireConfig & Save** | 4 条 | 28~31 |
+| **通用最佳实践** | 3 条 | 33, 34, 36 |
+
+**总计：新增 26 条坑点**
+
+---
+
+## 自检报告
+
+### 与现有 1~9 条重复检查
+
+| 新增条目 | 是否重复 | 说明 |
+|---------|---------|------|
+| 10) method 参数大小写 | 否 | 新增：Patching 层面 |
+| 11) Constructor Patch | 否 | 新增：Patching 层面 |
+| 12) Locator 多匹配 | 否 | 新增：Patching 层面 |
+| 13) Patch 顺序依赖 | 否 | 新增：Patching 层面 |
+| 14) 反射私有字段 | 否 | 新增：Patching 层面 |
+| 15) @ByRef 参数 | 否 | 新增：Patching 层面 |
+| 16) $proceed 占位符 | 否 | 与 9) 相关但更通用（9) 是 static call 特例） |
+| 17) method = "<class>" | 否 | 新增：Patching 层面 |
+| 18) paramtypez 匹配 | 否 | 新增：Patching 层面 |
+| 19) 路径大小写敏感 | 否 | 扩展：1) 的深化版 |
+| 20) ClassLoader 路径 | 否 | 新增：资源打包层面 |
+| 21) 中文路径/空格 | 否 | 新增：资源命名层面 |
+| 22) atlas-json 配对 | 否 | 新增：Spine 资源层面 |
+| 23) orbTextures 结构 | 否 | 扩展：3) 的深化版 |
+| 24) Localization 时机 | 否 | 新增：多语言层面 |
+| 25) UTF-8 编码 | 否 | 新增：多语言层面 |
+| 26) ID 前缀冲突 | 否 | 新增：IDs 命名层面 |
+| 27) @SpireEnum 与 ID | 否 | 新增：Enum 与 ID 区分 |
+| 28) SpireConfig 时机 | 否 | 新增：Config 层面 |
+| 29) 存档膨胀 | 否 | 新增：Save 层面 |
+| 30) 版本迁移 | 否 | 新增：Save 层面 |
+| 31) 竞态条件 | 否 | 新增：Save 层面 |
+| 32) Localization 文件命名 | 否 | 新增：多语言层面 |
+| 33) modid 与资源目录 | 否 | 新增：路径约定层面 |
+| 34) abstractSaveString 误用 | 否 | 新增：Save API 层面 |
+| 35) Keywords 注册 | 否 | 新增：多语言层面 |
+| 36) @SpireInsert vs Replace | 否 | 新增：Patching 层面 |
+
+### 泛化/不可验证条目检查
+
+| 条目 | 问题 | 修正 |
+|------|------|------|
+| 无 | 所有条目均有证据指针和具体检查方法 | - |
+
+---
+
+## 最终可追加文本（删除重复后）
+
+**可追加内容**：第 10~35 条（共 26 条新增内容），格式与现有 docs/pitfalls.md 完全一致。
+
+**追加方式**：直接将 docs/pitfalls-additions.md 中第 10~35 条的内容复制粘贴到 docs/pitfalls.md 第 9 条之后即可。

--- a/docs/plans/2026-01-13-mods-pitfalls-survey.md
+++ b/docs/plans/2026-01-13-mods-pitfalls-survey.md
@@ -1,0 +1,153 @@
+# STS Mods Pitfalls Survey Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** 调查本机 `../resources/mods/` 下的已解包模组实现方式，补充 `docs/pitfalls.md` 的“踩坑记录 + 最佳实践”，减少后续开发反复试错。
+
+**Architecture:** 用脚本/检索把 119 个模组的“共性写法/高频模式”抽成证据清单（mod + 文件路径 + 片段关键词），再把这些证据归纳成可操作的坑点条目（现象/根因/解决/检查清单），最后回填到 `docs/pitfalls.md` 并与本项目现有代码对齐。
+
+**Tech Stack:** `bash`, `rg` (ripgrep), `jq` (可选), `python` (可选), Markdown
+
+---
+
+## Task 1: 确定输出规范与边界
+
+**Files:**
+- Modify: `docs/pitfalls.md`
+- Create (optional, 用于留证据): `docs/references/mod-survey/README.md`
+- Create (optional): `docs/references/mod-survey/evidence.md`
+
+**Step 1: 约束“允许写进文档的内容”**
+- 只写“现象/根因/解决/检查项”，不要复制粘贴任何第三方 mod 的成段代码
+- 如需举例，只能给“关键词/伪代码/接口名”，并给出对照来源的 `modName/relativePath` 作为指引
+- 每条坑点尽量能落到“我下一步应该改哪”或“我下一步应该怎么验证”
+
+**Step 2: 定义坑点条目的统一模板**
+- 标题：一句话描述坑点（不要太泛）
+- 现象：游戏里看到什么/日志里报什么
+- 根因：为什么会这样（BaseMod/MTS/STS 机制点）
+- 解决：推荐做法 + 最小示例（伪代码/关键 API）
+- 快速自检：1~3 条 checklist（能用命令/测试/日志验证更好）
+
+---
+
+## Task 2: 盘点 119 个 mod 的基本画像（语言/结构/依赖）
+
+**Files:**
+- Create (optional): `docs/references/mod-survey/inventory.md`
+
+**Step 1: 收集 ModTheSpire.json 元信息**
+
+Run:
+```bash
+find ../resources/mods -maxdepth 2 -name 'ModTheSpire.json' -print
+```
+
+**Step 2: 抽取依赖与版本线索（BaseMod / StSLib / MTS）**
+
+Run:
+```bash
+rg -n '"dependencies"|"modid"|"name"|"version"|"author"' ../resources/mods -S --glob='ModTheSpire.json'
+```
+
+**Step 3: 结构画像（典型目录约定）**
+
+Run:
+```bash
+find ../resources/mods -maxdepth 2 -type d -print | rg -n '/(cards|relics|characters|patches|powers|localization|img|images|audio|effects)(/|$)' -S
+```
+
+---
+
+## Task 3: 按主题做“高频模式扫描”（为坑点条目找证据）
+
+**Files:**
+- Modify: `docs/references/mod-survey/evidence.md` (optional)
+
+**Step 1: CustomPlayer / 角色骨架 / 动画与资源加载**
+Run:
+```bash
+rg -n "extends CustomPlayer|new CustomPlayer\\(|loadAnimation\\(|Spine|skeleton|atlas|\\.json" ../resources/mods -S --glob='*.java' --glob='*.kt'
+```
+
+**Step 2: BaseMod Subscriber 生命周期与注册时机**
+Run:
+```bash
+rg -n "receive(Edit|PostInitialize|OnStart|StartGame|AddAudio|EditKeywords|EditStrings|EditCharacters|EditCards|EditRelics)" ../resources/mods -S --glob='*.java' --glob='*.kt'
+```
+
+**Step 3: @SpireEnum 冲突与声明习惯**
+Run:
+```bash
+rg -n "@SpireEnum" ../resources/mods -S --glob='*.java' --glob='*.kt'
+```
+
+**Step 4: SpirePatch / InsertPatch / Locator / LineFinder**
+Run:
+```bash
+rg -n "@SpirePatch|@SpireInsertPatch|SpireInsertLocator|LineFinder\\.|ExprEditor|javassist" ../resources/mods -S --glob='*.java' --glob='*.kt'
+```
+
+**Step 5: Localization（编码/前缀/回退/keywords）**
+Run:
+```bash
+rg -n "localization|CardCrawlGame\\.languagePack|loadCustomStrings|addKeyword|keywords\\.json|strings\\.json|UTF-8" ../resources/mods -S --glob='*.java' --glob='*.kt' --glob='*.json'
+```
+
+**Step 6: Prefs / SaveData / config**
+Run:
+```bash
+rg -n "SpireConfig|Preferences|getPrefs\\(|save\\(|load\\(|onSave\\(|onLoad\\(" ../resources/mods -S --glob='*.java' --glob='*.kt'
+```
+
+---
+
+## Task 4: 从证据归纳“可写进 pitfalls.md 的条目”
+
+**Files:**
+- Modify: `docs/pitfalls.md`
+
+**Step 1: 按类别扩展章节（建议顺序）**
+- CustomPlayer（动画/资源/能量球/选择界面）
+- Patching（method/ctor/locator/static call/patch order）
+- Enums & IDs（@SpireEnum + ID 前缀 + 冲突）
+- Localization（字符串/keywords/编码/回退）
+- 资源加载与打包（路径、大小写、jar 内外差异）
+- Save & Config（SpireConfig/Prefs 的时机与兼容）
+
+**Step 2: 每条坑点至少满足一个“可验证”要素**
+- 有可复现症状（或日志关键词）
+- 有明确根因（机制点）
+- 有明确解决动作（修改点）
+- 有自检办法（命令/测试/观察点）
+
+---
+
+## Task 5: 与本项目现状对齐（避免写成“别人的坑”）
+
+**Files:**
+- Modify: `docs/pitfalls.md`
+- Reference: `src/main/kotlin/theforget/**`
+
+**Step 1: 对每条新增坑点标注“本项目是否已规避/是否待办”**
+- 已规避：写“本项目现状/相关文件”即可
+- 未规避：写“建议后续 issue：xxx”
+
+**Step 2: 保持文风一致**
+- 继续使用现有格式：编号条目 + 现象/根因/解决 + 必要时命令块
+
+---
+
+## Task 6: 最终检查与交付
+
+**Files:**
+- Modify: `docs/pitfalls.md`
+
+**Step 1: 合规检查**
+- 没有出现第三方 mod 的大段代码
+- 所有引用都只到“mod 名 + 文件路径 + 关键词”
+
+**Step 2: 可读性检查**
+- 目录结构清晰（按类别组织）
+- 每条尽量能让开发者“5 分钟内定位到问题”
+

--- a/docs/skills/sts-mod-pitfalls/SKILL.md
+++ b/docs/skills/sts-mod-pitfalls/SKILL.md
@@ -1,0 +1,114 @@
+---
+name: sts-mod-pitfalls
+description: Slay the Spire Mod 开发踩坑规范。提供 Patching、CustomPlayer、Localization 等场景的常见坑点、证据指针和自检方法。处理 @SpirePatch、Spine 动画、SpireConfig、Localization 时使用。
+---
+
+# STS Mod 开发踩坑规范
+
+## 何时使用
+
+开发 Slay the Spire mod 时遇到以下场景时激活：
+
+- 使用 `@SpirePatch` 进行代码注入
+- 实现 `CustomPlayer` 自定义角色
+- 处理 Spine 动画/资源加载
+- 配置多语言文案
+- 实现存档持久化
+
+## 快速索引
+
+| 主题 | 坑点数量 | 关键风险 |
+|------|---------|---------|
+| Patching | 10 类 | Patch 无效/崩溃 |
+| CustomPlayer | 14 条 | 资源加载失败 |
+| Localization | 12 项 | 文案不显示/乱码 |
+
+## 核心原则
+
+1. **资源路径规范**：使用 `ModTheSpire.json` 声明的 resources 前缀
+2. **回调时序规则**：receiveEditStrings → receiveEditCards → receiveEditRelics → receivePostInitialize
+3. **Patch 注入策略**：优先 SpireInsertPatch，再用 SpireInstrumentPatch
+4. **ID 命名约定**：所有 ID 使用 `modID:EntityName` 格式
+
+## 详细参考
+
+- **Patching**：见 [references/PATCHING.md](references/PATCHING.md) - 10 类常见坑点
+- **CustomPlayer**：见 [references/CUSTOMPLAYER.md](references/CUSTOMPLAYER.md) - 14 条资源相关坑点
+- **Localization**：见 [references/LOCALIZATION.md](references/LOCALIZATION.md) - 12 项多语言配置坑点
+- **检查清单**：见 [templates/checklist.md](templates/checklist.md) - 开发前/中/后自检清单
+
+## 坑点总览
+
+### Patching 坑点
+
+1. **构造函数 Patch**：用 `<ctor>` 而非 `<init>`
+2. **反射私有字段**：硬编码字符串的脆弱性
+3. **SpireInsert vs SpireInstrument**：选择策略混乱
+4. **Javassist 占位符**：`$proceed`/`$$`/`$_` 使用错误
+5. **SpireField 初始化**：`null.INSTANCE` 陷阱
+6. **SpireReturn 泛型**：与返回值类型不匹配
+7. **Matcher 多匹配**：导致 patch 位置错误
+8. **paramtypez 参数**：类型错误或顺序错误
+9. **Patch 类命名**：组织结构混乱
+10. **Locator 实现**：模式不一致
+
+### CustomPlayer/资源坑点
+
+1. **路径大小写敏感**：Windows 正常，Linux 崩溃
+2. **打包进 jar 后路径变化**：File API 无法访问
+3. **atlas-json 配对错误**：文件不匹配或版本不一致
+4. **资源未在 ModTheSpire.json 声明**：打包后加载失败
+5. **orbTextures/orbVfxPath 传 null**：复用原版红色能量球
+6. **layer1..6d 资源缺失**：无能量状态显示异常
+7. **layerSpeeds 数组长度不匹配**：动画速度异常
+8. **ScreenShake 参数过强**：选中角色抖动很久
+9. **选中效果/头像资源缺失**：显示黑色方块
+10. **loadAnimation 调用时机错误**：模型不显示
+11. **tooltip 坐标硬编码**：画到屏幕外
+12. **TipHelper.renderGenericTip 不展开 NL**：显示字面量
+13. **updateTips 回调顺序问题**：tooltip 延迟显示
+14. **占位复用原版资源边界**：哪些行为危险
+
+### Localization/配置坑点
+
+1. **加载时机错误**：构造函数中调用 loadCustomStringsFile
+2. **UTF-8 编码问题**：中文显示乱码
+3. **语言回退机制缺失**：不支持语言崩溃
+4. **Keywords 注册时机错误**：在 receiveEditStrings 中调用
+5. **ID 前缀缺失**：与其他 mod 冲突
+6. **NL 换行符使用错误**：混淆 NL 与 \n
+7. **SpireConfig 创建时机不当**：早期代码无法访问
+8. **getPrefs 时机问题**：过早访问未初始化配置
+9. **onSave/onLoad 实现不完整**：存档数据无法恢复
+10. **版本升级迁移缺失**：旧存档失效
+11. **存档膨胀问题**：保存过多数据
+12. **abstractSaveString/abstractSaveSpecial 使用场景**：何时使用
+
+## 证据来源
+
+本地解包 mod：`../resources/mods/`（119 个 mod）
+
+主要参考：
+- **LingMod**：`lingmod/character/Ling.java` - 角色实现、路径管理
+- **Downfall**：`slimebound/patches/` - Patch 组织结构
+- **BaseMod**：`basemod/abstracts/CustomPlayer.java` - 基类实现
+- **StSLib**：`StSLib/patches/` - 高级 Patch 技术
+- **WljMod**：`WljMod.java` - 完整的回调时序
+- **AyaMod**：`AyaMod.java` - 资源路径工具方法
+- **AnonMod**：`characters/char_Anon.java` - 能量球配置
+
+## 快速自检
+
+```bash
+# 检查构造函数 patch
+rg 'method\s*=\s*"<init>"' --type java
+
+# 检查 UTF-8 编码
+rg 'readString\(' --type java | grep -v UTF_8
+
+# 检查 ID 前缀
+rg '"[A-Z][a-zA-Z]+:' --type json | grep -v 'ModTheSpire|base'
+
+# 检查 SpireField 初始化
+rg 'new SpireField' --type java -A 1 | grep -E '(null\.INSTANCE|::|\(\) ->)'
+```

--- a/docs/skills/sts-mod-pitfalls/references/CUSTOMPLAYER.md
+++ b/docs/skills/sts-mod-pitfalls/references/CUSTOMPLAYER.md
@@ -1,0 +1,441 @@
+# CustomPlayer 资源相关坑点参考
+
+开发 STS 角色类 mod 时的常见资源加载问题，聚焦 CustomPlayer、Spine 动画、能量球、角色选择界面、TopPanel/tooltip。
+
+---
+
+## 1. 路径大小写敏感
+
+**现象**：Windows 下正常，Linux/Mac 下游戏崩溃或资源加载失败。
+
+**根因**：Linux 文件系统区分大小写，Windows 不区分。代码中的路径与实际文件名大小写不匹配。
+
+**推荐做法**：
+```java
+// 正确做法：使用工具函数统一路径管理
+public class ModPaths {
+    public static String makeCharPath(String file) {
+        return "ModResources/images/char/" + file;
+    }
+}
+loadAnimation(ModPaths.makeCharPath("player.atlas"), ModPaths.makeCharPath("player.json"), 1.0F);
+```
+
+**证据指针**：
+- `Downfall/sneckomod/TheSnecko.java:51` - 使用动态路径变量
+- `LingMod/lingmod/character/Ling.java:77-80` - 使用 `ModCore.makeCharacterPath()`
+
+**自检命令**：
+```bash
+# 检查代码中的路径与实际文件名大小写是否匹配
+find ../resources/mods -name "*.java" -exec grep -l "\.atlas\|\.json" {} \; | xargs grep -oh "[^\"']*\.[Aa][Tt][Ll][Aa][Ss]"
+```
+
+---
+
+## 2. 打包进 jar 后路径变化
+
+**现象**：IDE 运行正常，打包后游戏崩溃。报错信息包含 `classpath` 或 `ClassLoader` 相关。
+
+**根因**：开发时使用 `File API` 访问文件系统路径，打包后资源在 jar 内，必须使用 `ClassLoader.getResource()`。
+
+**推荐做法**：
+```java
+// 错误示例：使用 File API
+File file = new File("images/char/player.png");  // 打包后无法访问
+
+// 正确做法：使用 Gdx.files.internal
+Texture tex = new Texture(Gdx.files.internal("ModResources/images/char/player.png"));
+```
+
+**证据指针**：
+- `BaseMod/basemod/abstracts/CustomPlayer.java:212` - 使用 `Gdx.files.internal`
+- `AnonMod/characters/char_Anon.java:83` - 直接使用 `new SpriterAnimation(filepath)`
+
+**自检命令**：
+```bash
+grep -rn "new File\(" ../resources/mods --include="*.java"
+```
+
+---
+
+## 3. atlas-json 配对错误
+
+**现象**：角色动画不显示或显示错乱。报 `Spine: Skeleton not found` 或 `Atlas region not found`。
+
+**根因**：`.atlas` 文件和 `.json` 文件不匹配，或使用了不同版本的 Spine 导出。
+
+**推荐做法**：
+```java
+// 确保同名配对
+String basePath = "ModResources/images/char/player";
+loadAnimation(basePath + ".atlas", basePath + ".json", 1.0F);
+
+// 验证文件存在性
+if (Gdx.files.internal(basePath + ".atlas").exists() &&
+    Gdx.files.internal(basePath + ".json").exists()) {
+    loadAnimation(...);
+}
+```
+
+**证据指针**：
+- `BaseMod/basemod/abstracts/CustomPlayer.java:78` - 构造函数中自动调用 `loadAnimation`
+- `Downfall/sneckomod/TheSnecko.java:51` - 使用动态路径确保配对
+
+**自检命令**：
+```bash
+# 检查 atlas 和 json 文件是否成对存在
+find ../resources/mods -name "*.atlas" | while read f; do
+  json="${f%.atlas}.json"
+  if [ ! -f "$json" ]; then echo "Missing pair: $f"; fi
+done
+```
+
+---
+
+## 4. 资源未放在 ModTheSpire.json 声明的 resources 目录
+
+**现象**：IDE 运行正常，打包后资源加载失败。报错 `Resource not found: xxxResources/...`。
+
+**根因**：`ModTheSpire.json` 未声明资源目录，或声明路径与实际不符。
+
+**推荐做法**：
+```json
+// ModTheSpire.json
+{
+  "resources": ["ModResources/"]
+}
+```
+
+```java
+// 代码中的路径前缀必须与声明一致
+public static final String RESOURCE_PATH = "ModResources/";
+loadAnimation(RESOURCE_PATH + "images/char/player.atlas", ...);
+```
+
+**证据指针**：
+- `LingMod/lingmod/ModCore.java:makeCharacterPath()` - 使用统一前缀 `ModResources`
+- `Koishi/Koishi/characters/KoishiCharacter.java:51` - 使用 `KoishiResources` 前缀
+
+**自检命令**：
+```bash
+grep -h "\"resources\"" -A10 ../resources/mods/*/ModTheSpire.json
+```
+
+---
+
+## 5. orbTextures/orbVfxPath 传 null 导致复用原版资源
+
+**现象**：自定义角色使用了铁甲师的红色能量球。
+
+**根因**：`CustomEnergyOrb` 构造函数在 `orbTexturePaths == null` 时回退到 `ImageMaster.ENERGY_RED_*`。
+
+**推荐做法**：
+```java
+// 占位阶段：复用原版能量球
+super(name, playerClass, (String[])null, null, (String)null, (String)null);
+
+// 正式版：提供完整资源
+private static final String[] ORB_TEXTURES = new String[] {
+    "ModResources/images/char/orb/layer1.png",
+    // ... 共 11 个文件
+};
+super(name, playerClass, ORB_TEXTURES, "ModResources/images/char/orb/vfx.png", LAYER_SPEED, ...);
+```
+
+**证据指针**：
+- `BaseMod/basemod/abstracts/CustomEnergyOrb.java:38-52` - null 处理逻辑
+- `LingMod/lingmod/character/Ling.java:65` - 传入 `(String)null, (String)null)`
+
+**自检命令**：
+```bash
+grep -rn "orbTextures.*null\|orbVfxPath.*null" ../resources/mods --include="*.java"
+```
+
+---
+
+## 6. layer1..6d 资源缺失导致渲染异常
+
+**现象**：能量球有能量时正常，无能量时显示白色方块或消失。
+
+**根因**：`orbTextures` 数组长度应为奇数（中间是 base，前后对称），缺少无能量状态的层（带 d 后缀的文件）。
+
+**推荐做法**：
+```java
+// 正确的数组结构：[enabled1..5, base, disabled1..5]
+// 总共 11 个元素（5层+base+5层）
+private static final String[] ORB_TEXTURES = new String[] {
+    "layer1.png", "layer2.png", "layer3.png", "layer4.png", "layer5.png",
+    "layer6.png",  // base
+    "layer1d.png", "layer2d.png", "layer3d.png", "layer4d.png", "layer5d.png"
+};
+```
+
+**证据指针**：
+- `BaseMod/basemod/abstracts/CustomEnergyOrb.java:22-25` - 长度和奇数校验
+- `Downfall/sneckomod/TheSnecko.java:35` - 完整的 11 层数组
+
+**自检命令**：
+```bash
+ls ModResources/images/char/orb/{layer{1..5}.png,layer6.png,layer{1..5}d.png}
+```
+
+---
+
+## 7. layerSpeeds 数组长度不匹配
+
+**现象**：能量球动画速度异常。报错 `ArrayIndexOutOfBoundsException`。
+
+**根因**：`layerSpeeds` 长度必须等于 `orbTextures.length / 2`（层数）。
+
+**推荐做法**：
+```java
+// 5层动画需要5个速度值
+private static final float[] LAYER_SPEED = new float[] {
+    -20.0F,   // layer1 逆时针
+    20.0F,    // layer2 顺时针
+    -40.0F,   // layer3 快速逆时针
+    40.0F,    // layer4 快速顺时针
+    360.0F    // layer5 特效层旋转
+};
+```
+
+**证据指针**：
+- `BaseMod/basemod/abstracts/CustomEnergyOrb.java:55-62` - 默认值和校验
+- `AnonMod/characters/char_Anon.java:48` - 完整的 10 元素速度数组
+
+**自检命令**：
+```bash
+grep -A10 "LAYER_SPEED" ../resources/mods --include="*.java" | grep "new float\[\]" -A10
+```
+
+---
+
+## 8. ScreenShake 参数过强导致"抖动很久"
+
+**现象**：点击角色后屏幕剧烈震动，持续数秒。
+
+**根因**：`ShakeIntensity.HIGH` 或 `ShakeDur.LONG` 参数过于极端。
+
+**推荐做法**：
+```java
+@Override
+public void doCharSelectScreenSelectEffect() {
+    CardCrawlGame.sound.playA("SELECT_SOUND", MathUtils.random(-0.2F, 0.2F));
+    CardCrawlGame.screenShake.shake(
+        ShakeIntensity.LOW,   // 或 MED，避免 HIGH
+        ShakeDur.SHORT,       // 避免 LONG、VERY_LONG
+        false
+    );
+}
+```
+
+**证据指针**：
+- `Downfall/sneckomod/TheSnecko.java:90` - 使用 `ShakeIntensity.LOW, ShakeDur.SHORT`
+- `Koishi/Koishi/characters/KoishiCharacter.java:87` - 同样的 LOW/SHORT 组合
+
+**自检命令**：
+```bash
+grep -rn "ShakeIntensity.HIGH\|ShakeDur.LONG\|ShakeDur.VERY_LONG" ../resources/mods --include="*.java"
+```
+
+---
+
+## 9. 选中效果/头像资源缺失
+
+**现象**：角色选择界面头像显示为黑色方块。
+
+**根因**：`initializeClass` 参数中的 shoulder1/shoulder2/corpse 路径错误或文件不存在。
+
+**推荐做法**：
+```java
+public static final String SHOULDER1 = ModPaths.makeCharPath("shoulder.png");
+public static final String SHOULDER2 = ModPaths.makeCharPath("shoulder2.png");
+public static final String CORPSE = ModPaths.makeCharPath("corpse.png");
+
+// 构造时验证
+if (Gdx.files.internal(SHOULDER1).exists()) {
+    this.initializeClass(null, SHOULDER1, SHOULDER2, CORPSE, getLoadout(), ...);
+}
+```
+
+**证据指针**：
+- `AnonMod/characters/char_Anon.java:42-44` - 定义 SELES_SHOULDER/SELES_CORPSE 常量
+- `LingMod/lingmod/character/Ling.java:51-52` - 使用 `ModCore.makeCharacterPath()`
+
+**自检命令**：
+```bash
+ls ModResources/images/char/{shoulder.png,shoulder2.png,corpse.png}
+```
+
+---
+
+## 10. loadAnimation 调用时机错误
+
+**现象**：角色模型不显示或显示默认姿势。
+
+**根因**：`loadAnimation` 未在构造函数中调用，或 `SpineAnimation` 的 atlasUrl/skeletonUrl 设置错误。
+
+**推荐做法**：
+```java
+// 方式1：通过 CustomPlayer 构造函数自动调用
+public MyCharacter(String name, PlayerClass setClass) {
+    super(name, setClass, orbTextures, orbVfx, new SpineAnimation(
+        "ModResources/images/char/player.atlas",
+        "ModResources/images/char/player.json",
+        1.0F
+    ));
+    // CustomPlayer 构造函数会自动调用 loadAnimation
+}
+
+// 方式2：手动调用
+public void reloadAnimation() {
+    this.loadAnimation(atlasUrl, skeletonUrl, scale);
+    AnimationState.TrackEntry e = this.state.setAnimation(0, "Idle", true);
+    e.setTime(e.getEndTime() * MathUtils.random());
+}
+```
+
+**证据指针**：
+- `BaseMod/basemod/abstracts/CustomPlayer.java:76-79` - 自动调用 `loadAnimation`
+- `Downfall/sneckomod/TheSnecko.java:50-56` - 手动 `reloadAnimation` 方法
+
+**自检命令**：
+```bash
+grep -rn "loadAnimation" ../resources/mods --include="*Character.java"
+```
+
+---
+
+## 11. tooltip 坐标硬编码导致画到屏幕外
+
+**现象**：鼠标悬停时 tooltip 不显示，或显示位置偏移。
+
+**根因**：`TipHelper.renderGenericTip` 使用了固定坐标，未考虑 `Settings.scale` 缩放因子。
+
+**推荐做法**：
+```java
+// 错误示例：硬编码坐标
+TipHelper.renderGenericTip(1500.0F, 700.0F, title, body);
+
+// 正确做法：使用相对坐标 + Settings.scale
+protected void onHover() {
+    if (this.hitbox.hovered) {
+        float tipX = 1550.0F * Settings.scale;
+        float tipY = (Settings.HEIGHT - 120.0F) * Settings.scale;
+        TipHelper.renderGenericTip(tipX, tipY, TEXT[0], TEXT[1]);
+    }
+}
+```
+
+**证据指针**：
+- `LingMod/lingmod/ui/PoetryTopPanel.java:168` - 使用 `Settings.scale`
+- `KeyCuts/test447/keycuts/patches/ProceedButtonPatches.java:73` - 动态计算 x - 140.0F * Settings.scale
+
+**自检命令**：
+```bash
+grep -rn "renderGenericTip" ../resources/mods --include="*.java" | grep -v "Settings.scale"
+```
+
+---
+
+## 12. TipHelper.renderGenericTip 不展开 NL
+
+**现象**：tooltip 文本中的 `\n` 显示为字面量而非换行。
+
+**根因**：`TipHelper.renderGenericTip` 不会自动处理换行符。
+
+**推荐做法**：
+```java
+// 方式1：手动换行（推荐）
+String[] paragraphs = new String[] {
+    "第一段内容",
+    "第二段内容",
+    "第三段内容"
+};
+TipHelper.renderGenericTip(x, y, paragraphs[0], paragraphs[1] + " " + paragraphs[2]);
+
+// 方式2：预处理 NL
+String processed = body.replace(" NL ", "\n");
+TipHelper.renderGenericTip(x, y, title, processed);
+```
+
+**证据指针**：
+- `KeyCuts/test447/keycuts/patches/ProceedButtonPatches.java:70-73` - 使用 UIStrings.TEXT 数组
+- `LingMod/lingmod/ui/PoetryTopPanel.java:168` - 使用预定义的 TEXT[0], TEXT[1]
+
+**自检命令**：
+```bash
+grep -rn "renderGenericTip.*\\\\n" ../resources/mods --include="*.java"
+```
+
+---
+
+## 13. updateTips 回调顺序问题
+
+**现象**：自定义 TopPanel 的 tooltip 显示延迟或不显示。
+
+**根因**：`onHover()` 调用时机晚于原版渲染，未正确覆盖 `updateTips()` 回调。
+
+**推荐做法**：
+```java
+// TopPanelItem 中正确实现 onHover
+@Override
+protected void onHover() {
+    super.onHover();  // 先调用父类
+    if (this.hitbox.hovered) {
+        TipHelper.renderGenericTip(...);
+    }
+}
+```
+
+**证据指针**：
+- `LingMod/lingmod/ui/PoetryTopPanel.java:161-171` - 完整的 `onHover` 实现
+- `BaseMod/basemod/TopPanelItem.java` - 基类定义
+
+**自检命令**：
+```bash
+grep -A5 "protected void onHover()" ../resources/mods --include="*TopPanel*.java"
+```
+
+---
+
+## 14. 占位复用原版资源的边界
+
+**安全的行为**（占位阶段可接受）：
+- 能量球纹理：`orbTextures=null`, `orbVfxPath=null`（低风险）
+- 字体：`FontHelper.energyNumFontRed`（低风险）
+- 动画占位：`new SpriterAnimation(path)` 使用原版路径（低风险）
+
+**危险的行为**（可能导致冲突）：
+- `CardColor` 枚举：`return CardColor.RED;`（高风险：与铁甲师冲突）
+- 原版枚举值：`PlayerClass.IRONCLAD`（高风险：破坏角色系统）
+
+**推荐做法**：
+```java
+// 错误示例：复用 CardColor 枚举
+@Override
+public AbstractCard.CardColor getCardColor() {
+    return CardColor.RED;  // 危险！会与铁甲师混用卡池
+}
+
+// 正确做法：使用 SpireEnum 创建自定义枚举
+@SpireEnum
+public static AbstractPlayer.PlayerClass MY_CHARACTER;
+@SpireEnum
+public static AbstractCard.CardColor MY_COLOR;
+
+@Override
+public AbstractCard.CardColor getCardColor() {
+    return MY_COLOR;  // 安全，独立的卡池
+}
+```
+
+**证据指针**：
+- `Kikuchiyo/kikuchiyo/character/Kikuchiyo.java:108` - **危险示例**：直接返回 `CardColor.RED`
+- `BaseMod/basemod/abstracts/CustomPlayer.java:119-130` - 正确使用 `this.getCardColor()`
+
+**自检命令**：
+```bash
+grep -rn "return CardColor\.RED\|return CardColor\.BLUE\|return CardColor\.GREEN" ../resources/mods --include="*Character.java"
+```

--- a/docs/skills/sts-mod-pitfalls/references/LOCALIZATION.md
+++ b/docs/skills/sts-mod-pitfalls/references/LOCALIZATION.md
@@ -1,0 +1,439 @@
+# Localization、IDs、Prefs/Save 相关坑点参考
+
+聚焦多语言、ID 命名、配置持久化三大主题的常见陷阱。
+
+---
+
+## 1. 加载时机错误
+
+**现象**：不会报错，但多语言文本无法加载，游戏内显示 `MISSING:` 或 ID。
+
+**根因**：`receiveEditStrings()` 回调的调用时机早于构造函数执行。在构造函数中加载的字符串会被后续的回调覆盖。
+
+**推荐做法**：
+```java
+public class MyMod implements EditStringsSubscriber {
+    public void receiveEditStrings() {
+        // 正确：在回调中加载
+        String lang = getLocalizationLanguage();
+        BaseMod.loadCustomStringsFile(CardStrings.class,
+            "localization/" + lang + "/my_cards.json");
+    }
+}
+```
+
+**证据指针**：
+- `WljMod/wlj-mod-1.3.4`：在 `receiveEditStrings()` 回调中加载（行 173-206）
+- `AyaMod`：在 `receiveEditStrings()` 回调中加载（行 274-285）
+
+**自检命令**：
+```bash
+# 检查是否有在构造函数中调用 loadCustomStringsFile
+grep -rn "loadCustomStringsFile" ../resources/mods --include="*.java" -B 10 | grep -A 10 "public.*Mod.*("
+```
+
+---
+
+## 2. UTF-8 编码问题
+
+**现象**：中文、日文等多语言文本显示为乱码或方框。
+
+**根因**：`Gdx.files.internal().readString()` 默认使用系统编码，而非 UTF-8。
+
+**推荐做法**：
+```java
+// 正确：显式指定 UTF-8
+String json = Gdx.files.internal("localization/eng/my_keywords.json")
+    .readString(String.valueOf(StandardCharsets.UTF_8));
+```
+
+**证据指针**：
+- `WljMod`（行 192）：`readString(String.valueOf(StandardCharsets.UTF_8))`
+- `AyaMod`（行 290）：`readString(String.valueOf(StandardCharsets.UTF_8))`
+- `AnonMod`（行 446）：`readString(String.valueOf(StandardCharsets.UTF_8))`
+
+**自检命令**：
+```bash
+grep -rn 'readString\(' ../resources/mods --include="*.java" | grep -v 'UTF_8'
+```
+
+---
+
+## 3. 语言回退机制缺失
+
+**现象**：游戏语言设置为 `POR`（葡萄牙语）时，找不到对应本地化文件，崩溃或显示 `MISSING:`。
+
+**根因**：仅提供了部分语言（如 `eng`、`zhs`、`zht`），未设置默认回退到 `eng`。
+
+**推荐做法**：
+```java
+private String getLocalizationLanguage() {
+    switch (Settings.language) {
+        case ZHS: return "zhs";
+        case ZHT: return "zht";
+        case JPN: return "jpn";
+        // ... 其他支持的语言
+        default: return "eng"; // 默认回退到英文
+    }
+}
+```
+
+**证据指针**：
+- `WljMod`（行 175-182）：使用 `switch(Settings.language)` 并 `default` 到 `zhs`
+- `AyaMod`（行 197-206）：使用 `switch` 并 `default` 到 `eng`
+
+**自检命令**：
+```bash
+grep -A 10 "getLocalizationLanguage\|switch.*Settings.language" ../resources/mods --include="*.java" | grep -c "default"
+```
+
+---
+
+## 4. Keywords 注册时机错误
+
+**现象**：关键词提示文本显示为 ID 或 `MISSING:`。
+
+**根因**：`BaseMod.addKeyword()` 必须在 `receiveEditKeywords()` 回调中调用，而非 `receiveEditStrings()`。
+
+**推荐做法**：
+```java
+public void receiveEditKeywords() {
+    // 1. 先读取 JSON
+    String json = Gdx.files.internal("localization/" + lang + "/my_keywords.json")
+        .readString(String.valueOf(StandardCharsets.UTF_8));
+    Keyword[] keywords = new Gson().fromJson(json, Keyword[].class);
+
+    // 2. 在此回调中注册
+    for (Keyword keyword : keywords) {
+        BaseMod.addKeyword(
+            modID.toLowerCase(),  // 前缀
+            keyword.PROPER_NAME,
+            keyword.NAMES,
+            keyword.DESCRIPTION
+        );
+    }
+}
+```
+
+**证据指针**：
+- `WljMod`（行 149-156）：在 `receiveEditKeywords()` 中调用 `BaseMod.addKeyword()`
+- `AyaMod`（行 287-298）：在 `receiveEditKeywords()` 中调用 `BaseMod.addKeyword()`
+
+**自检命令**：
+```bash
+grep -B 5 -A 5 "addKeyword" ../resources/mods --include="*.java" | grep -B 10 "receiveEditKeywords"
+```
+
+---
+
+## 5. ID 前缀缺失
+
+**现象**：与其他 mod 的 ID 冲突，导致卡牌/遗物描述错乱。
+
+**根因**：ID 必须全局唯一，使用 `modID:` 前缀是社区约定。
+
+**推荐做法**：
+```java
+// 在 JSON 中
+{
+  "MyMod:Strike": {
+    "NAME": "Strike",
+    "DESCRIPTION": "Deal !D! damage."
+  }
+}
+
+// 在代码中
+public static final String ID = "MyMod:Strike";
+```
+
+**证据指针**：
+- `Downfall`：所有 ID 使用 `awakened:` 前缀（如 `awakened:Thunderbolt`）
+- `WljMod`：使用 `Wlj:` 前缀（如 `Wlj:Cup`）
+- `AyaMod`：使用 `theAya:` 前缀（如 `theAya:FlyingPotion`）
+
+**自检命令**：
+```bash
+# 检查 JSON 中是否有未使用 modID: 前缀的 ID
+grep -rh '"[A-Z][a-zA-Z]*:' ../resources/mods --include="*.json" | grep -v 'ModTheSpire\|base'
+```
+
+---
+
+## 6. NL 换行符使用错误
+
+**现象**：卡牌描述中的换行符不生效，显示为字面量 `NL` 或 `\n`。
+
+**根因**：`NL` 是 STS 的特殊标记，会在运行时展开为 `\n`。直接使用 `\n` 不会在描述中正确换行。
+
+**推荐做法**：
+```json
+// 正确：使用 NL 进行换行
+{
+  "MyMod:MyCard": {
+    "DESCRIPTION": "Gain !B! Block. NL Deal !D! damage. NL Exhaust."
+  }
+}
+
+// 错误：直接使用 \n
+{
+  "MyMod:MyCard": {
+    "DESCRIPTION": "Gain !B! Block.\nDeal !D! damage.\nExhaust."
+  }
+}
+```
+
+**证据指针**：
+- `Downfall`（CardStrings.json）：大量使用 `NL`
+- `HSRMod`（ui.json）：混合使用 `NL` 和普通文本
+
+**自检命令**：
+```bash
+# 检查 JSON 中是否使用了 \n 而非 NL
+grep -rh '\\\\n' ../resources/mods --include="*.json" | grep -v ' NL '
+```
+
+---
+
+## 7. SpireConfig 创建时机不当
+
+**现象**：
+- 在 `initialize()` 静态方法中创建，但未正确加载配置
+- 在 `receivePostInitialize()` 中创建，导致早期代码无法访问
+
+**根因**：`SpireConfig` 需要在 `initialize()` 或静态初始化块中创建并 `load()`。
+
+**推荐做法**：
+```java
+@SpireInitializer
+public class MyMod {
+    public static SpireConfig config;
+
+    static {
+        try {
+            Properties defaults = new Properties();
+            defaults.setProperty("mySetting", "false");
+            config = new SpireConfig("MyMod", "MyModConfig", defaults);
+            config.load();  // 立即加载
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+    }
+
+    public static void initialize() {
+        new MyMod();
+    }
+}
+```
+
+**证据指针**：
+- `WljMod`（行 96-100）：在构造函数中创建 `SpireConfig`
+- `AnonMod`（行 1042-1045）：在静态初始化块中创建 `SpireConfig saves`
+- `AyaMod`（行 110-116）：在构造函数中创建并 `load()` 配置
+
+**自检命令**：
+```bash
+grep -B 5 -A 5 "new SpireConfig" ../resources/mods --include="*.java"
+```
+
+---
+
+## 8. getPrefs 时机问题
+
+**现象**：在 `receiveEditCards()` 等早期回调中访问 `config.getBool()`，返回值不正确或抛出异常。
+
+**根因**：虽然 `SpireConfig` 已创建，但某些配置项可能需要延迟加载。
+
+**推荐做法**：
+```java
+// 使用 getter 方法，提供默认值
+public static boolean isMyFeatureEnabled() {
+    if (config == null) {
+        return false;  // 安全默认值
+    }
+    try {
+        return config.getBool("myFeature");
+    } catch (Exception e) {
+        return false;
+    }
+}
+
+// 在需要时才调用
+public void receiveEditCards() {
+    if (isMyFeatureEnabled()) {
+        // 添加特定卡牌
+    }
+}
+```
+
+**证据指针**：
+- `WljMod`（行 83-89）：使用 `getVoiceDisabled()` 方法，内部检查 `config == null`
+
+**自检命令**：
+```bash
+grep -B 3 "config.getBool\|config.getString" ../resources/mods --include="*.java" | grep -c "config == null"
+```
+
+---
+
+## 9. onSave/onLoad 实现不完整
+
+**现象**：存档中保存的数据无法正确恢复，读取存档后游戏行为异常。
+
+**根因**：`CustomSavable<T>` 接口需要正确实现 `onSave()` 和 `onLoad(T value)`。
+
+**推荐做法**：
+```java
+public class MyRelic extends CustomRelic implements CustomSavable<MySaveData> {
+    private int myCounter = 0;
+
+    @Override
+    public MySaveData onSave() {
+        MySaveData data = new MySaveData();
+        data.counter = this.myCounter;
+        return data;  // 返回实际数据
+    }
+
+    @Override
+    public void onLoad(MySaveData data) {
+        if (data != null) {
+            this.myCounter = data.counter;  // 恢复数据
+        }
+    }
+}
+```
+
+**证据指针**：
+- `GeniusSocietysDangerousGossip`（hsr-mod）：实现 `CustomSavable<Integer>`（行 56-64）
+- `Inner`（AnonMod）：实现 `CustomSavable<SoulHeartSave>`（行 34-39）
+
+**自检命令**：
+```bash
+grep -A 5 "public.*onSave()" ../resources/mods --include="*.java" | grep -c "return null"
+```
+
+---
+
+## 10. 版本升级迁移缺失
+
+**现象**：mod 更新后，玩家存档无法加载，或配置项丢失。
+
+**根因**：`SpireConfig` 不会自动迁移旧配置到新格式。
+
+**推荐做法**：
+```java
+static {
+    try {
+        Properties defaults = new Properties();
+        defaults.setProperty("version", "2.0");
+        defaults.setProperty("newFeature", "false");
+        config = new SpireConfig("MyMod", "MyModConfig", defaults);
+        config.load();
+
+        // 版本检查与迁移
+        String version = config.getString("version");
+        if ("1.0".equals(version)) {
+            migrateFromV1ToV2();
+        }
+    } catch (IOException e) {
+        e.printStackTrace();
+    }
+}
+
+private static void migrateFromV1ToV2() {
+    boolean oldSetting = config.getBool("oldSettingName");
+    config.setBool("newSettingName", oldSetting);
+    config.setString("version", "2.0");
+    config.save();
+}
+```
+
+**自检命令**：
+```bash
+grep -rn "version.*config\|migrate.*V" ../resources/mods --include="*.java"
+```
+
+---
+
+## 11. 存档膨胀问题
+
+**现象**：存档文件异常庞大，加载/保存速度变慢。
+
+**根因**：每次保存都写入大量数据，或保存了冗余信息。
+
+**推荐做法**：
+```java
+// 只保存必要数据
+@Override
+public Integer onSave() {
+    return this.myCounter;  // 仅保存一个 int
+}
+
+// 避免：保存大量数据
+// @Override
+// public Map<String, Object> onSave() {
+//     Map<String, Object> data = new HashMap<>();
+//     data.put("entireHistory", this.history);  // 可能有数千条记录
+//     return data;
+// }
+```
+
+**证据指针**：
+- `AnonMod`（SavemetricData.java）：使用独立的 SpireConfig (`sp-racing`, `saves`) 存储统计数据
+
+**自检命令**：
+```bash
+grep -A 10 "public.*onSave()" ../resources/mods --include="*.java" | grep -E "HashMap|ArrayList|LinkedList"
+```
+
+---
+
+## 12. abstractSaveString/abstractSaveSpecial 使用场景
+
+**何时使用**：
+
+**`abstractSaveString()`**：
+- 需要自定义序列化逻辑
+- 数据格式复杂（嵌套对象）
+- 需要与其他 mod 交互
+
+**`abstractSaveSpecial()`**：
+- 需要保存到特殊位置（非玩家存档）
+- 跨 run 持久化数据
+
+**推荐做法**：
+```java
+// 使用自定义序列化
+@Override
+public String onSave() {
+    return myCounter + ":" + myFlag;  // 自定义格式
+}
+
+@Override
+public void onLoad(String data) {
+    if (data != null && data.contains(":")) {
+        String[] parts = data.split(":");
+        this.myCounter = Integer.parseInt(parts[0]);
+        this.myFlag = Boolean.parseBoolean(parts[1]);
+    }
+}
+```
+
+**自检命令**：
+```bash
+grep -rn "abstractSaveString\|abstractSaveSpecial" ../resources/mods --include="*.java"
+```
+
+---
+
+## 回调时序速查
+
+| 操作 | 推荐时机 | 注意事项 |
+|------|---------|---------|
+| BaseMod.addColor | 主类构造函数 | 必须在 `receiveEditCharacters()` 之前 |
+| BaseMod.addCharacter | `receiveEditCharacters()` | 需确保 color 已注册 |
+| loadCustomStringsFile | `receiveEditStrings()` | 不在构造函数中调用 |
+| BaseMod.addKeyword | `receiveEditKeywords()` | 不在 `receiveEditStrings()` 中调用 |
+| BaseMod.addCard | `receiveEditCards()` | 确保 strings 已加载 |
+| BaseMod.addRelic | `receiveEditRelics()` | 确保 color 已注册 |
+| new SpireConfig | 静态初始化块或构造函数 | 立即调用 `load()` |
+| BaseMod.registerModBadge | `receivePostInitialize()` | 创建设置面板 |

--- a/docs/skills/sts-mod-pitfalls/references/PATCHING.md
+++ b/docs/skills/sts-mod-pitfalls/references/PATCHING.md
@@ -1,0 +1,321 @@
+# Patching 坑点参考
+
+基于 100+ 个开源 mod 的代码扫描总结，使用 `@SpirePatch` 的常见坑点。
+
+---
+
+## 1. 构造函数 Patch 的方法名陷阱
+
+**现象**：构造函数 patch 失效，编译时无错误但运行时不生效。
+
+**根因**：字节码中构造函数名为 `<init>`，但 SpirePatch 框架约定使用 `<ctor>`。
+
+**推荐做法**：
+```java
+@SpirePatch(
+    clz = StrikeEffect.class,
+    method = "<ctor>",  // 使用 <ctor>
+    paramtypez = {AbstractCreature.class, float.class, float.class, int.class}
+)
+```
+
+**证据指针**：
+- `Downfall/slimebound/patches/StrikeEffectPatch.java` + `method = "<ctor>"`
+- `BaseMod/basemod/patches/com/megacrit/cardcrawl/cards/AbstractCard/CardModifierPatches.java` + `method = "<ctor>"`
+
+**自检命令**：
+```bash
+rg 'method\s*=\s*"<init>"' --type java
+```
+
+---
+
+## 2. 反射私有字段的脆弱性
+
+**现象**：游戏更新后 mod 突然崩溃，报 `NoSuchFieldException`。
+
+**根因**：硬编码字段名字符串，游戏更新时字段名可能改变。
+
+**推荐做法**：
+```java
+// 脆弱写法（不推荐）
+Integer gold = (Integer) ReflectionHacks.getPrivate(__instance, "gold", Integer.class);
+
+// 优先使用 SpireField
+public static SpireField<Integer> gold = new SpireField(() -> 0);
+```
+
+**证据指针**：
+- `wlj-mod/com/github/paopaoyue/wljmod/patch/gold/GoldTextEffectPatch.java` + `Reflect.getPrivate`
+- `Downfall/patches/ui/topPanel/GoldToSoulPatches.java` + `ReflectionHacks.getPrivateStatic`
+
+**自检命令**：
+```bash
+rg 'ReflectionHacks\.getPrivate[^;]+\.[a-zA-Z]+\s*\)' --type java -C 2
+```
+
+---
+
+## 3. SpireInsert 与 SpireInstrument 的选择混乱
+
+**现象**：同样功能有的用 `@SpireInsertPatch`，有的用 `@SpireInstrumentPatch`，代码风格不统一。
+
+**根因**：两种方式适用场景不同：
+- `SpireInsertPatch` + Locator：更清晰，适合在已知位置插入
+- `SpireInstrumentPatch` + ExprEditor：更灵活，适合复杂条件插入
+
+**推荐做法**：
+```java
+// 场景1：在方法调用前插入（推荐 SpireInsertPatch）
+@SpireInsertPatch(locator = Locator.class)
+public static void Insert(SpriteBatch sb) { }
+
+// 场景2：条件性替换方法调用（推荐 SpireInstrumentPatch）
+@SpireInstrumentPatch
+public static ExprEditor Instrument() {
+    return new ExprEditor() {
+        public void edit(MethodCall m) throws CannotCompileException {
+            if (m.getClassName().equals(SpriteBatch.class.getName())) {
+                m.replace("{ if(condition) { $proceed($$); } }");
+            }
+        }
+    };
+}
+```
+
+**证据指针**：
+- `mintySpire/patches/BetterAscensionSelectorPatches.java:72` + `@SpireInstrumentPatch`
+- `ArknightsTheSpire/patches/PreHealPatcher.java` + `@SpireInsertPatch`
+
+**自检命令**：
+```bash
+rg '@SpireInsertPatch' --type java | wc -l
+rg '@SpireInstrumentPatch' --type java | wc -l
+```
+
+---
+
+## 4. Javassist 占位符使用错误
+
+**现象**：patch 运行时崩溃，报 `NotFoundException` 或参数不匹配错误。
+
+**根因**：Javassist 占位符有特定含义：
+- `$0` = this（实例方法）或第一个参数（静态方法）
+- `$$` = 所有参数
+- `$proceed(...)` = 调用原始方法
+- `$_` = 返回值
+
+**推荐做法**：
+```java
+// 正确：传递所有参数
+m.replace("{ if(!condition) { $proceed($$); } }");
+
+// 正确：修改返回值
+f.replace("$_ = $proceed($$) || alternative();");
+
+// 错误：无参方法用 $$
+// m.replace("{ $proceed($$); }")  // 错误！原始方法无参数
+```
+
+**证据指针**：
+- `mintySpire/patches/BetterAscensionSelectorPatches.java:78` + `$proceed($$)`
+- `ThePackmaster/patches/needlework/FineTuneLineWidthPatch.java:57` + `$_ = $proceed($$)`
+
+**自检命令**：
+```bash
+rg '\$proceed' --type java -B 2 -A 2 | head -60
+```
+
+---
+
+## 5. SpireField 初始化的 null.INSTANCE 陷阱
+
+**现象**：使用 SpireField 添加字段时，访问字段抛出 `NullPointerException`。
+
+**根因**：SpireField 构造函数需要 `Supplier<T>` 作为默认值工厂，`null.INSTANCE` 会导致 Supplier 为 null。
+
+**推荐做法**：
+```java
+// 错误写法
+public static SpireField<String> name = new SpireField(null.INSTANCE);
+
+// 正确写法
+public static SpireField<String> name = new SpireField(() -> "default");
+public static SpireField<Integer> count = new SpireField(() -> 0);
+```
+
+**证据指针**：
+- `rare-cards-sparkle/RareCardsSparkleFields.java:41-43` + `new SpireField(null.INSTANCE)`
+- `ThePackmaster/patches/needlework/StitchPatches.java:36` + `new SpireField(() -> null)`
+
+**自检命令**：
+```bash
+rg 'new SpireField' --type java -A 1 | grep -E '(null\.INSTANCE|::|\(\) ->)'
+```
+
+---
+
+## 6. SpireReturn 泛型与返回值不匹配
+
+**现象**：使用 `@SpirePrefixPatch` 提前返回时，编译错误或运行时类型转换异常。
+
+**根因**：`SpireReturn.Return()` 用于 void 方法，`SpireReturn.Return(value)` 用于非 void 方法。
+
+**推荐做法**：
+```java
+// void 方法
+@SpirePrefixPatch
+public static SpireReturn<Void> Prefix(SomeClass __instance) {
+    if (shouldSkip) {
+        return SpireReturn.Return(null);  // void 方法返回 null
+    }
+    return SpireReturn.Continue();
+}
+
+// 非void 方法
+@SpirePrefixPatch
+public static SpireReturn<AbstractStance> Prefix(String name) {
+    if (name.equals("Custom")) {
+        return SpireReturn.Return(new CustomStance());
+    }
+    return SpireReturn.Continue();
+}
+```
+
+**证据指针**：
+- `wlj-mod/com/github/paopaoyue/wljmod/patch/gold/GoldTextEffectPatch.java` + `SpireReturn<Void>`
+- `Mizuki/patches/StancePatch.java` + `SpireReturn<AbstractStance>`
+
+**自检命令**：
+```bash
+rg 'SpireReturn\.Return' --type java -B 3
+```
+
+---
+
+## 7. Matcher 多匹配导致 patch 位置错误
+
+**现象**：patch 应该影响第 N 次调用，但实际影响的是第 1 次。
+
+**根因**：`Matcher.MethodCallMatcher` 默认只匹配第一个符合条件的调用。
+
+**推荐做法**：
+```java
+// 场景：只匹配第一次（默认行为）
+Matcher finalMatcher = new Matcher.MethodCallMatcher(ExhaustPanel.class, "render");
+return LineFinder.findInOrder(ctBehavior, finalMatcher);
+
+// 场景：匹配所有位置
+return LineFinder.findAllInOrder(ctBehavior, finalMatcher);
+
+// 场景：匹配第 N 次
+int[] allMatches = LineFinder.findAllInOrder(ctBehavior, matcher);
+return new int[]{ allMatches[2] };  // 只取第 3 次
+```
+
+**证据指针**：
+- `ArknightsTheSpire/ui/SpUtil.java:53` + `MethodCallMatcher`
+- `LingMod/lingmod/powers/NI3Power.java:65` + `MethodCallMatcher`
+
+**自检命令**：
+```bash
+rg 'Matcher\.(MethodCall|FieldAccess|NewExpr)' --type java -A 3
+```
+
+---
+
+## 8. paramtypez 参数类型错误
+
+**现象**：patch 不生效，无错误提示；或 patch 应用到了错误的重载方法上。
+
+**根因**：`paramtypez` 用于区分重载方法，常见错误：
+1. 类型不匹配（如用 `Integer.class` 而非 `int.class`）
+2. 参数顺序错误
+
+**推荐做法**：
+```java
+// 正确：使用基本类型
+@SpirePatch(
+    clz = AbstractPlayer.class,
+    method = "damage",
+    paramtypez = {DamageInfo.class}  // 单参数重载
+)
+
+// 错误：使用包装类型
+// paramtypez = {Integer.class}  // 错误！应该是 int.class
+```
+
+**证据指针**：
+- `ArknightsTheSpire/patches/PreHealPatcher.java:13` + `paramtypez = {int.class, boolean.class}`
+
+**自检命令**：
+```bash
+rg 'paramtypez\s*=' --type java -A 1
+```
+
+---
+
+## 9. Patch 类命名和组织混乱
+
+**现象**：难以找到特定功能的 patch，同名 patch 冲突。
+
+**根因**：不同 mod 使用不同的组织方式。
+
+**推荐做法**：
+```
+yourmod/
+└── patches/
+    ├── com/
+    │   └── megacrit/
+    │       └── cardcrawl/
+    │           ├── cards/
+    │           │   └── AbstractCardPatches.java
+    │           └── ui/
+    │               └── TopPanelPatches.java
+    └── locators/
+        └── CustomLocator.java
+```
+
+**证据指针**：
+- `Downfall/slimebound/patches/` - 结构清晰
+- `ThePackmaster/patches/turmoilpack/` - 按包组织
+
+**自检命令**：
+```bash
+find ../resources/mods -type d -name "patches" -exec sh -c 'echo "=== {} ===" && ls {} | head -10' \;
+```
+
+---
+
+## 10. Locator 实现模式不一致
+
+**现象**：Locator 代码重复，不清楚何时用 `findInOrder` vs `findAllInOrder`。
+
+**根因**：`findInOrder` 只返回第一个匹配位置，`int[]` 返回值的含义不清晰。
+
+**推荐做法**：
+```java
+// 模式1：简单的单点插入（内部类）
+private static class Locator extends SpireInsertLocator {
+    public int[] Locate(CtBehavior ctBehavior) throws Exception {
+        Matcher finalMatcher = new Matcher.MethodCallMatcher(TargetClass.class, "targetMethod");
+        return LineFinder.findInOrder(ctBehavior, finalMatcher);
+    }
+}
+
+// 模式2：多点插入（findAllInOrder）
+private static class Locator extends SpireInsertLocator {
+    public int[] Locate(CtBehavior ctBehavior) throws Exception {
+        return LineFinder.findAllInOrder(ctBehavior, finalMatcher);
+    }
+}
+```
+
+**证据指针**：
+- `ArknightsTheSpire/ui/SpUtil.java:51` - 内部类 Locator
+- `rare-cards-sparkle/locators/RenderTipLocator.java` - 独立类
+
+**自检命令**：
+```bash
+rg 'extends\s+SpireInsertLocator' --type java -A 10 | head -80
+```

--- a/docs/skills/sts-mod-pitfalls/templates/checklist.md
+++ b/docs/skills/sts-mod-pitfalls/templates/checklist.md
@@ -1,0 +1,187 @@
+# STS Mod 开发检查清单
+
+本文档提供开发前、中、后的自检清单，帮助避免常见坑点。
+
+## 开发前检查
+
+### 基础配置
+- [ ] Mod ID 已定义并与 ModTheSpire.json 一致
+- [ ] 资源路径前缀已在 ModTheSpire.json 声明
+- [ ] 目录结构符合社区规范
+
+### 角色开发
+- [ ] 卡色使用 `@SpireEnum` 创建自定义枚举
+- [ ] 能量球资源完整（11 层纹理：layer1..5 + layer6 + layer1d..5d）
+- [ ] layerSpeeds 数组长度为 5（对应 5 层动画）
+- [ ] 角色选择资源存在（shoulder.png, shoulder2.png, corpse.png）
+- [ ] Spine 动画文件配对（.atlas + .json 同名）
+
+---
+
+## Patching 检查
+
+### 构造函数 Patch
+- [ ] 构造函数 patch 使用 `<ctor>` 而非 `<init>`
+- [ ] paramtypez 使用基本类型（`int.class` 而非 `Integer.class`）
+
+### Javassist 占位符
+- [ ] 无参方法使用 `$proceed()` 而非 `$proceed($$)`
+- [ ] 静态方法不使用 `$0` 访问实例
+- [ ] 返回值修改使用 `$_ = $proceed($$)`
+
+### SpireField
+- [ ] SpireField 初始化提供 Supplier（`new SpireField(() -> defaultValue)`）
+- [ ] 不使用 `null.INSTANCE`
+
+### SpireReturn
+- [ ] void 方法使用 `SpireReturn<Void>` + `SpireReturn.Return(null)`
+- [ ] 非void 方法使用具体类型 + `SpireReturn.Return(value)`
+
+### Matcher 和 Locator
+- [ ] 确认目标方法中匹配的方法/字段只出现一次，或使用 `findAllInOrder`
+- [ ] Locator 实现选择合适：简单用内部类，复用用独立类
+
+---
+
+## Localization 检查
+
+### 加载时机
+- [ ] `loadCustomStringsFile` 在 `receiveEditStrings()` 中调用
+- [ ] 不在构造函数中调用本地化加载方法
+
+### 编码和回退
+- [ ] `readString()` 显式指定 `StandardCharsets.UTF_8`
+- [ ] 语言回退到 `eng`（switch 包含 `default` 分支）
+
+### Keywords
+- [ ] `addKeyword()` 在 `receiveEditKeywords()` 回调内调用
+- [ ] 传入的第一个参数是 `modID.toLowerCase()`
+
+### ID 命名
+- [ ] 所有 ID 使用 `modID:EntityName` 格式
+- [ ] JSON 文件中的 key 都使用 `modID:` 前缀
+- [ ] 描述使用 ` NL ` 进行换行（前后有空格）
+
+---
+
+## 资源和配置检查
+
+### 资源路径
+- [ ] 资源路径前缀与 ModTheSpire.json 声明一致
+- [ ] 使用 `Gdx.files.internal()` 而非 `File API`
+- [ ] 路径大小写与实际文件名匹配（考虑 Linux 兼容）
+
+### SpireConfig
+- [ ] SpireConfig 在静态初始化块或构造函数中创建
+- [ ] 创建后立即调用 `config.load()`
+- [ ] 不在 `receivePostInitialize()` 等回调中创建配置
+- [ ] 配置访问通过 getter 方法包装，包含 `config == null` 检查
+
+### 存档持久化
+- [ ] `CustomSavable.onSave()` 返回非 null 数据
+- [ ] `onLoad()` 处理 null 输入的情况
+- [ ] 保存的数据尽可能精简（基本类型优先）
+- [ ] 配置文件包含版本号字段
+- [ ] 有版本迁移逻辑
+
+---
+
+## UI 和渲染检查
+
+### Tooltip
+- [ ] tooltip 坐标使用 `Settings.scale` 缩放
+- [ ] 不使用硬编码坐标（如 `1500.0F, 700.0F`）
+- [ ] 处理 NL 换行符（手动替换或分段）
+- [ ] TopPanel 的 `onHover()` 调用 `super.onHover()`
+
+### ScreenShake
+- [ ] 角色选择震动使用 `ShakeIntensity.LOW/MED` + `ShakeDur.SHORT`
+- [ ] 避免使用 `HIGH` + `LONG`/`VERY_LONG`
+
+---
+
+## 自测验证命令
+
+```bash
+# ===== Patching 检查 =====
+
+# 检查构造函数 patch 是否错误使用 <init>
+rg 'method\s*=\s*"<init>"' --type java
+
+# 检查 paramtypez 是否使用包装类型
+rg 'paramtypez.*Integer\.class\|paramtypez.*Boolean\.class' --type java
+
+# 检查 SpireField 初始化
+rg 'new SpireField' --type java -A 1 | grep -E 'null\.INSTANCE'
+
+# 检查 Javassist 占位符使用
+rg '\$proceed' --type java -B 2 -A 2 | head -60
+
+# ===== Localization 检查 =====
+
+# 检查 UTF-8 编码
+rg 'readString\(' --type java | grep -v 'UTF_8'
+
+# 检查 ID 前缀
+rg '"[A-Z][a-zA-Z]+:' --type json | grep -v 'ModTheSpire|base'
+
+# 检查 Keywords 注册位置
+grep -B 10 'addKeyword' --type java | grep -A 5 'receiveEditStrings'
+
+# ===== 资源检查 =====
+
+# 检查是否使用 File API
+grep -rn "new File\(" --include="*.java"
+
+# 检查 atlas/json 配对
+find . -name "*.atlas" | while read f; do
+  json="${f%.atlas}.json"
+  if [ ! -f "$json" ]; then echo "Missing pair: $f"; fi
+done
+
+# 检查 orbTextures 是否传 null
+grep -rn "orbTextures.*null\|orbVfxPath.*null" --include="*.java"
+
+# 检查硬编码坐标（未使用 Settings.scale）
+grep -rn "renderGenericTip.*[0-9]\+\.[0-9]\+F" --include="*.java" | grep -v "Settings.scale"
+
+# 检查过激的 ScreenShake 参数
+grep -rn "ShakeIntensity.HIGH\|ShakeDur.LONG\|ShakeDur.VERY_LONG" --include="*.java"
+
+# ===== 配置检查 =====
+
+# 检查 SpireConfig 创建位置
+grep -B 10 "new SpireConfig" --include="*.java" | grep -E "receivePostInitialize|static"
+
+# 检查 onSave 返回 null
+grep -A 3 "public.*onSave()" --include="*.java" | grep "return null"
+```
+
+---
+
+## 常见问题速查
+
+### 问题：patch 不生效
+1. 检查 `method` 参数：构造函数用 `<ctor>`
+2. 检查 `paramtypez`：使用基本类型，顺序正确
+3. 检查 Matcher：确认目标方法中只匹配一次
+
+### 问题：多语言文本不显示
+1. 检查 `loadCustomStringsFile` 是否在 `receiveEditStrings()` 中调用
+2. 检查 `readString()` 是否指定 `UTF_8`
+3. 检查 ID 是否使用 `modID:` 前缀
+
+### 问题：资源加载失败
+1. 检查 ModTheSpire.json 中的 resources 声明
+2. 检查路径大小写（Linux 兼容）
+3. 检查是否使用 `Gdx.files.internal()`
+
+### 问题：tooltip 显示异常
+1. 检查坐标是否使用 `Settings.scale`
+2. 检查 NL 是否手动处理
+3. 检查 `onHover()` 是否调用 `super.onHover()`
+
+### 问题：存档数据丢失
+1. 检查 `onSave()` 是否返回非 null
+2. 检查 `onLoad()` 是否处理 null
+3. 检查配置版本迁移逻辑


### PR DESCRIPTION
## 概述

添加 STS Mod 开发踩坑规范技能和调研文档，帮助后续开发避免常见陷阱。

## 新增内容

### 1. Agent Skills 技能
- `docs/skills/sts-mod-pitfalls/` - STS Mod 开发踩坑规范技能
  - SKILL.md - 主文件（含快速索引、核心原则）
  - references/PATCHING.md - 10 类 Patching 坑点
  - references/CUSTOMPLAYER.md - 14 条 CustomPlayer/资源坑点
  - references/LOCALIZATION.md - 12 项多语言配置坑点
  - templates/checklist.md - 开发检查清单

### 2. 调研报告
- `docs/investigation-report.md` - 119 个 mod 的盘点结果
- `docs/patching-pitfalls.md` - Patching 坑点详细文档
- `docs/customplayer-resources-pitfalls.md` - CustomPlayer/资源坑点详细文档
- `docs/localization-ids-prefs-pitfalls.md` - Localization/配置坑点详细文档
- `docs/pitfalls-additions.md` - 可追加到 pitfalls.md 的新增条目

### 3. 证据来源
所有坑点都包含：
- 证据指针（mod 名 + 文件路径 + 关键词）
- 可执行的自检命令

## 测试计划
- [x] 所有文档符合 Agent Skills 规范
- [x] 每个坑点都有证据指针和自检命令
- [x] 文件结构清晰，便于查阅

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>